### PR TITLE
🔧 `copier`: update package template to v0.11.1

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v0.6.0
+_commit: v0.11.1
 _src_path: https://github.com/mbercx/python-copier
 description: AiiDA plugin package for interfacing with the Electron Phonon Wannier
     (EPW) code.

--- a/.github/workflows/.ci.yml
+++ b/.github/workflows/.ci.yml
@@ -1,0 +1,36 @@
+name: ci
+
+on: [push, pull_request]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install Hatch
+        run: |
+          pip install click==8.2.1 hatch
+          hatch env prune
+
+      - name: Run pre-commit
+        run: hatch run pre-commit:run
+
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.13']
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install click==8.1.8 hatch
+      - run: hatch test

--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,6 @@ __marimo__/
 docs/_build
 
 dev/
+# Jupytext sync is a tool for writing notebooks in `.ipynb` format, and syncing them to a `.md` file
+# https://marketplace.visualstudio.com/items?itemName=caenrigen.jupytext-sync
+.jupytext-sync-ipynb

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,11 @@
 repos:
-- repo: local
-  hooks:
-  - id: format
-    name: Format with Ruff
-    entry: hatch fmt -f
-    language: system
-    types: [python]
-  - id: Lint with Ruff
-    name: lint
-    entry: hatch fmt -l
-    language: system
-    types: [python]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.13.2
+    hooks:
+      - id: ruff-check
+        name: Lint with Ruff
+        types_or: [ python, pyi ]
+        args: [ --fix ]
+      - id: ruff-format
+        name: Format with Ruff
+        types_or: [ python, pyi ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,9 +6,9 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'aiida-epw'
-copyright = '2025, Marnik Bercx'
-author = 'Marnik Bercx'
+project = "aiida-epw"
+copyright = "2025, Marnik Bercx"
+author = "Marnik Bercx"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -16,10 +16,10 @@ author = 'Marnik Bercx'
 extensions = ["myst_parser"]
 myst_enable_extensions = ["dollarmath", "amsmath"]
 
-templates_path = ['_templates']
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'sphinx_book_theme'
+html_theme = "sphinx_book_theme"

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -1,32 +1,193 @@
 # Developer Guide
 
-## Hatch
+## Quick start
 
-We use [Hatch](https://hatch.pypa.io/latest) to set up environments and scripts for most developer tasks.
-To see a table of the available environmens and their scripts, run:
+Thanks for contributing! 🙏
+Below you can find an overview of the commands to get you up and running quickly.
 
-    hatch env show
+First clone the repository from GitHub
 
-### Documentation
+    git clone <GITHUB-REPO>
 
-The easiest way to work on the documentation is to start the server locally via:
+and install the package locally in **editable** mode (`-e`):
 
-    hatch run docs:serve
+    cd aiida-epw
+    pip install -e .
 
-And go to the provided URL.
-If you only want to build the documentation locally, there is also a script for that:
+:::{note}
+We support various tools for developers.
+Select your preferred one from the tabs below.
+If you don't know `uv` or Hatch, stick with the default for now.
+:::
 
-    hatch run docs:build
+::::{tab-set}
+:::{tab-item} Default
+
+The "default" approach to developing is to install the development extras in your current environment:
+
+    pip install -e .[pre-commit,tests,docs]
+
+🔧 **Pre-commit**
+
+To make sure your changes adhere to our formatting/linting preferences, install the pre-commit hooks:
+
+    pre-commit install
+
+They will then run on every `git commit`.
+You can also run them on e.g. all files using:
+
+    pre-commit run -a
+
+Drop the `-a` option in case you only want to run on staged files.
+
+🧪 **Tests**
+
+You can run all tests in the `tests` directory with `pytest`:
+
+    pytest
+
+Or select the test module:
+
+    pytest tests/parsers/test_pw.py
+
+See the [`pytest` documentation](https://docs.pytest.org/en/stable/how-to/usage.html#specifying-which-tests-to-run) for more information.
+
+📚 **Documentation**
+
+We use [MyST](https://mystmd.org/) as our documentation framework.
+Go into the `docs` directory and start the documentation server with:
+
+    myst start
+
+and open the documentation in your browser via the link shown.
+Every time you save a file, the corresponding documentation page is updated automatically!
 
 A GitHub action is set up to automatically deploy the documentation to GitHub Pages.
 See [the corresponding GitHub Pages documentation](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-from-a-branch) for the steps required.
 
-### Pre-commit
+:::
+:::{tab-item} uv
 
-You can install the [pre-commit](https://pre-commit.com/) hooks with:
+`uv` is a Python package and project manager.
+See [the documentation](https://docs.astral.sh/uv/getting-started/installation/) on how to install `uv`.
 
-    hatch run precommit:install
+🔧 **Pre-commit**
 
-Or run them via:
+To make sure your changes adhere to our formatting/linting preferences, install the pre-commit hooks:
 
-    hatch run precommit:install
+    uvx pre-commit install
+
+They will then run on every `git commit`.
+You can also run them on e.g. all files using:
+
+    uvx pre-commit run -a
+
+Drop the `-a` option in case you only want to run on staged files.
+
+```{note}
+Here we use the [`uvx` command](https://docs.astral.sh/uv/guides/tools/#running-tools) to run the `pre-commit` tool without installing it.
+Alternatively you can also install [`pre-commit` as a tool](https://docs.astral.sh/uv/guides/tools/#installing-tools) and omit `uvx`.
+```
+
+🧪 **Tests**
+
+You can run all tests in the `tests` directory with `pytest`:
+
+    uv run pytest
+
+Or select the test module:
+
+    uv run pytest tests/parsers/test_pw.py
+
+See the [`pytest` documentation](https://docs.pytest.org/en/stable/how-to/usage.html#specifying-which-tests-to-run) for more information.
+
+📚 **Documentation**
+
+We use [MyST](https://mystmd.org/) as our documentation framework.
+Go into the `docs` directory and start the documentation server with:
+
+    myst start
+
+and open the documentation in your browser via the link shown.
+Every time you save a file, the corresponding documentation page is updated automatically!
+
+A GitHub action is set up to automatically deploy the documentation to GitHub Pages.
+See [the corresponding GitHub Pages documentation](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-from-a-branch) for the steps required.
+
+:::
+:::{tab-item} Hatch
+
+You can use [Hatch](https://hatch.pypa.io/1.9/install/) to run development tools in isolated environments.
+To see a table of the available environments and their scripts, run:
+
+    hatch env show
+
+🔧 **Pre-commit**
+
+To make sure your changes adhere to our formatting/linting preferences, install the pre-commit hooks:
+
+    hatch run pre-commit:install
+
+They will then run on every `git commit`.
+You can also run them on e.g. all files using:
+
+    hatch run pre-commit:run -a
+
+Drop the `-a` option in case you only want to run on staged files.
+
+🧪 **Tests**
+
+You can run all tests in the `tests` directory using:
+
+    hatch test
+
+Or select the test module:
+
+    hatch test tests/parsers/test_pw.py
+
+You can also run the tests for a specific Python version with the `-py` option:
+
+    hatch test -py 3.11
+
+Or all supported Python `versions` with `--all`:
+
+    hatch test --all
+
+See the [Hatch documentation](https://hatch.pypa.io/1.12/tutorials/testing/overview/) for more information.
+
+📚 **Documentation**
+
+We use [MyST](https://mystmd.org/) as our documentation framework.
+Start the documentation server with:
+
+    hatch run docs:serve
+
+and open the documentation in your browser via the link shown.
+Every time you save a file, the corresponding documentation page is updated automatically!
+
+A GitHub action is set up to automatically deploy the documentation to GitHub Pages.
+See [the corresponding GitHub Pages documentation](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-from-a-branch) for the steps required.
+
+:::
+::::
+
+
+## Pre-commit rules
+
+From the extensive [Ruff ruleset](https://docs.astral.sh/ruff/rules/), we ignore the following globally:
+
+| Code      | Rule                                                                                                                      | Rationale / Note                                                                                                                    |
+| --------- | ------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `TRY003`  | [raise-vanilla-args](https://docs.astral.sh/ruff/rules/raise-vanilla-args/)                                               | Formatting warning/exception messages beforehand makes the code less readable, for a minor benefit in readability of the exception. |
+| `EM101`   | [raw-string-in-exception](https://docs.astral.sh/ruff/rules/raw-string-in-exception/)                                     | Same as `TRY003`                                                                                                                    |
+| `EM102`   | [f-string-in-exception](https://docs.astral.sh/ruff/rules/f-string-in-exception/)                                         | Same as `TRY003`                                                                                                                    |
+| `PLR2004` | [magic-value-comparison](https://docs.astral.sh/ruff/rules/magic-value-comparison/)                                       | We have a lot of “magic values” to compare with in scientific code; naming them all would reduce readability for little benefit.    |
+| `FBT002`  | [boolean-default-value-positional-argument](https://docs.astral.sh/ruff/rules/boolean-default-value-positional-argument/) | We understand the concept, but adhering to this rule is not a small change in syntax; disable for now.                              |
+| `TID252`  | [relative-imports](https://docs.astral.sh/ruff/rules/relative-imports/)                                                   | We don’t mind relative imports; as long as you don’t go up a level, they’re more readable (less verbose).                           |
+
+And the following rules for the files in the `tests` directory:
+
+| Code      | Rule                                                                                                                      | Rationale / Note                                                                                                                    |
+| --------- | ------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `INP001`  | [implicit-namespace-package](https://docs.astral.sh/ruff/rules/implicit-namespace-package/)                               | When tests are not part of the package, there is no need for `__init__.py` files.                                                   |
+| `S101`    | [assert](https://docs.astral.sh/ruff/rules/assert/)                                                                       | Asserts should not be used in production environments, but are fine for tests.                                                      |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,17 +41,55 @@ Source = "https://github.com/aiidaplugins/aiida-epw"
 'epw.epw_prep' = 'aiida_epw.workflows.prep:EpwPrepWorkChain'
 'epw.supercon' = 'aiida_epw.workflows.supercon:SuperConWorkChain'
 
+[project.optional-dependencies]
+docs = [
+"mystmd"
+]
+tests = [
+  "pytest"
+]
+pre-commit = [
+  "pre-commit"
+]
+
+[dependency-groups]
+dev = [
+  "aiida-epw[docs,tests,pre-commit]",
+]
+
 [tool.hatch.version]
 path = "src/aiida_epw/__about__.py"
 
+[tool.hatch.envs.default]
+installer = 'uv'
+
 [tool.hatch.envs.docs]
-dependencies = [
-  "mystmd"
-]
+features = ["docs"]
 scripts.build = "cd docs && myst build"
 scripts.serve = "cd docs && myst start"
 
-[tool.hatch.envs.precommit]
-dependencies = ["pre-commit"]
+[tool.hatch.envs.pre-commit]
+features = ["pre-commit"]
 scripts.install = "pre-commit install"
-scripts.run = "pre-commit run {args:--all-files}"
+scripts.run = "pre-commit run {args}"
+
+[tool.hatch.envs.hatch-test]
+features = ["tests"]
+randomize = false
+parallel = false
+run = "pytest {args}"
+
+[[tool.hatch.envs.hatch-test.matrix]]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
+
+[tool.ruff]
+lint.ignore = [
+    "TRY003",  # https://docs.astral.sh/ruff/rules/raise-vanilla-args/
+    "EM101",   # https://docs.astral.sh/ruff/rules/raw-string-in-exception/
+    "EM102",   # https://docs.astral.sh/ruff/rules/f-string-in-exception/
+    "PLR2004", # https://docs.astral.sh/ruff/rules/magic-value-comparison/
+    "FBT002",  # https://docs.astral.sh/ruff/rules/boolean-default-value-positional-argument/
+    "TID252",  # https://docs.astral.sh/ruff/rules/relative-imports/
+]
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["INP001", "S101"]

--- a/src/aiida_epw/__init__.py
+++ b/src/aiida_epw/__init__.py
@@ -1,3 +1,3 @@
 """AiiDA plugin package for interfacing with the Electron Phonon Wannier (EPW) code."""
 
-__version__ = '0.1.0'
+__version__ = "0.1.0"

--- a/src/aiida_epw/calculations/epw.py
+++ b/src/aiida_epw/calculations/epw.py
@@ -1,4 +1,5 @@
 """Plugin to create a Quantum Espresso epw.x input file."""
+
 from pathlib import Path
 
 from aiida import orm
@@ -16,27 +17,37 @@ class EpwCalculation(CalcJob):
     """`CalcJob` implementation for the epw.x code of Quantum ESPRESSO."""
 
     # Keywords that cannot be set by the user but will be set by the plugin
-    _blocked_keywords = [('INPUTEPW', 'outdir'), ('INPUTEPW', 'verbosity'), ('INPUTEPW', 'prefix'),
-                         ('INPUTEPW', 'dvscf_dir'), ('INPUTEPW', 'amass'), ('INPUTEPW', 'nq1'), ('INPUTEPW', 'nq2'),
-                         ('INPUTEPW', 'nq3'), ('INPUTEPW', 'nk1'), ('INPUTEPW', 'nk2'), ('INPUTEPW', 'nk3')]
+    _blocked_keywords = [
+        ("INPUTEPW", "outdir"),
+        ("INPUTEPW", "verbosity"),
+        ("INPUTEPW", "prefix"),
+        ("INPUTEPW", "dvscf_dir"),
+        ("INPUTEPW", "amass"),
+        ("INPUTEPW", "nq1"),
+        ("INPUTEPW", "nq2"),
+        ("INPUTEPW", "nq3"),
+        ("INPUTEPW", "nk1"),
+        ("INPUTEPW", "nk2"),
+        ("INPUTEPW", "nk3"),
+    ]
 
     _use_kpoints = True
 
-    _compulsory_namelists = ['INPUTEPW']
+    _compulsory_namelists = ["INPUTEPW"]
 
     # Default input and output files
-    _PREFIX = 'aiida'
-    _DEFAULT_INPUT_FILE = 'aiida.in'
-    _kfpoints_input_file = 'kfpoints.kpt'
-    _qfpoints_input_file = 'qfpoints.kpt'
-    _DEFAULT_OUTPUT_FILE = 'aiida.out'
-    _OUTPUT_XML_TENSOR_FILE_NAME = 'tensors.xml'
-    _OUTPUT_A2F_FILE = 'aiida.a2f'
-    _OUTPUT_SUBFOLDER = './out/'
-    _output_elbands_file = 'band.eig'
-    _output_phbands_file = 'phband.freq'
-    _FOLDER_SAVE = 'save'
-    _FOLDER_DYNAMICAL_MATRIX = 'DYN_MAT'
+    _PREFIX = "aiida"
+    _DEFAULT_INPUT_FILE = "aiida.in"
+    _kfpoints_input_file = "kfpoints.kpt"
+    _qfpoints_input_file = "qfpoints.kpt"
+    _DEFAULT_OUTPUT_FILE = "aiida.out"
+    _OUTPUT_XML_TENSOR_FILE_NAME = "tensors.xml"
+    _OUTPUT_A2F_FILE = "aiida.a2f"
+    _OUTPUT_SUBFOLDER = "./out/"
+    _output_elbands_file = "band.eig"
+    _output_phbands_file = "phband.freq"
+    _FOLDER_SAVE = "save"
+    _FOLDER_DYNAMICAL_MATRIX = "DYN_MAT"
 
     # Not using symlink in pw to allow multiple nscf to run on top of the same scf
     _default_symlink_usage = False
@@ -108,10 +119,10 @@ class EpwCalculation(CalcJob):
 
         def test_offset(offset):
             """Check if the grid has an offset."""
-            if any(i != 0. for i in offset):
+            if any(i != 0.0 for i in offset):
                 raise NotImplementedError(
-                    'Computation of electron-phonon on a mesh with non zero offset is not implemented, '
-                    'at the level of epw.x'
+                    "Computation of electron-phonon on a mesh with non zero offset is not implemented, "
+                    "at the level of epw.x"
                 )
 
         local_copy_list = []
@@ -119,66 +130,86 @@ class EpwCalculation(CalcJob):
         remote_symlink_list = []
         retrieve_list = [self.metadata.options.output_filename]
 
-        parameters = _uppercase_dict(self.inputs.parameters.get_dict(), dict_name='parameters')
+        parameters = _uppercase_dict(
+            self.inputs.parameters.get_dict(), dict_name="parameters"
+        )
         parameters = {k: _lowercase_dict(v, dict_name=k) for k, v in parameters.items()}
 
-        if 'INPUTEPW' not in parameters:
-            raise exceptions.InputValidationError('required namelist INPUTEPW not specified')
+        if "INPUTEPW" not in parameters:
+            raise exceptions.InputValidationError(
+                "required namelist INPUTEPW not specified"
+            )
 
-        if 'settings' in self.inputs:
-            settings = _uppercase_dict(self.inputs.settings.get_dict(), dict_name='settings')
+        if "settings" in self.inputs:
+            settings = _uppercase_dict(
+                self.inputs.settings.get_dict(), dict_name="settings"
+            )
         else:
             settings = {}
 
-        remote_list = remote_symlink_list if settings.pop(
-            'PARENT_FOLDER_SYMLINK', self._default_symlink_usage
-        ) else remote_copy_list
+        remote_list = (
+            remote_symlink_list
+            if settings.pop("PARENT_FOLDER_SYMLINK", self._default_symlink_usage)
+            else remote_copy_list
+        )
 
-        if 'parent_folder_nscf' in self.inputs:
+        if "parent_folder_nscf" in self.inputs:
             parent_folder_nscf = self.inputs.parent_folder_nscf
 
-            remote_list.append((
-                parent_folder_nscf.computer.uuid,
-                Path(parent_folder_nscf.get_remote_path(), PwCalculation._OUTPUT_SUBFOLDER).as_posix(),
-                self._OUTPUT_SUBFOLDER,
-            ))
-            
+            remote_list.append(
+                (
+                    parent_folder_nscf.computer.uuid,
+                    Path(
+                        parent_folder_nscf.get_remote_path(),
+                        PwCalculation._OUTPUT_SUBFOLDER,
+                    ).as_posix(),
+                    self._OUTPUT_SUBFOLDER,
+                )
+            )
+
         # If parent_folder_chk is provided, we need to copy the .chk, .bvec, and .mmn files to the epw folder.
         # We can do symlink for .chk and .bvec. .mmn file is already a symlink as defined in wannier workflow.
         # Note that we do some modification to the .mmn file in site so here we rename it to avoid overwriting.
-        if 'parent_folder_chk' in self.inputs:
+        if "parent_folder_chk" in self.inputs:
             parent_folder_chk = self.inputs.parent_folder_chk
 
-            for suffix in ['chk', 'bvec']:
+            for suffix in ["chk", "bvec"]:
                 remote_list.append(
                     (
-                        parent_folder_chk.computer.uuid, 
-                        Path(parent_folder_chk.get_remote_path(), self._PREFIX + '.' + suffix).as_posix(),
-                        self._PREFIX + '.' + suffix
+                        parent_folder_chk.computer.uuid,
+                        Path(
+                            parent_folder_chk.get_remote_path(),
+                            self._PREFIX + "." + suffix,
+                        ).as_posix(),
+                        self._PREFIX + "." + suffix,
                     )
                 )
             remote_list.append(
                 (
-                    parent_folder_chk.computer.uuid, 
-                    Path(parent_folder_chk.get_remote_path(), self._PREFIX + '.mmn').as_posix(),
-                    self._PREFIX + '.wannier90.mmn'
+                    parent_folder_chk.computer.uuid,
+                    Path(
+                        parent_folder_chk.get_remote_path(), self._PREFIX + ".mmn"
+                    ).as_posix(),
+                    self._PREFIX + ".wannier90.mmn",
                 )
             )
 
-        if 'parent_folder_ph' in self.inputs:
+        if "parent_folder_ph" in self.inputs:
             parent_folder_ph = self.inputs.parent_folder_ph
 
             # Create the save folder with dvscf and dyn files
             folder.get_subfolder(self._FOLDER_SAVE, create=True)
 
-            if 'NUMBER_OF_QPOINTS' in settings:
-                nqpt = settings.pop('NUMBER_OF_QPOINTS')
+            if "NUMBER_OF_QPOINTS" in settings:
+                nqpt = settings.pop("NUMBER_OF_QPOINTS")
             else:
                 # List of IBZ q-point to be added below EPW. To be removed when removed from EPW.
                 qibz_ar = []
-                for key, value in sorted(parent_folder_ph.creator.outputs.output_parameters.get_dict().items()):
-                    if key.startswith('dynamical_matrix_'):
-                        qibz_ar.append(value['q_point'])
+                for key, value in sorted(
+                    parent_folder_ph.creator.outputs.output_parameters.get_dict().items()
+                ):
+                    if key.startswith("dynamical_matrix_"):
+                        qibz_ar.append(value["q_point"])
 
                 nqpt = len(qibz_ar)
 
@@ -193,15 +224,27 @@ class EpwCalculation(CalcJob):
             ph_path = Path(parent_folder_ph.get_remote_path())
 
             remote_list.append(
-                (parent_folder_ph.computer.uuid, Path(ph_path, outdir, '_ph0', f'{prefix}.phsave').as_posix(), 'save')
+                (
+                    parent_folder_ph.computer.uuid,
+                    Path(ph_path, outdir, "_ph0", f"{prefix}.phsave").as_posix(),
+                    "save",
+                )
             )
 
             for iqpt in range(1, nqpt + 1):
-                remote_list.append((
-                    parent_folder_ph.computer.uuid,
-                    Path(ph_path, outdir, '_ph0', '' if iqpt == 1 else f'{prefix}.q_{iqpt}',
-                         f'{prefix}.{fildvscf}1').as_posix(), Path('save', f'{prefix}.dvscf_q{iqpt}').as_posix()
-                ))
+                remote_list.append(
+                    (
+                        parent_folder_ph.computer.uuid,
+                        Path(
+                            ph_path,
+                            outdir,
+                            "_ph0",
+                            "" if iqpt == 1 else f"{prefix}.q_{iqpt}",
+                            f"{prefix}.{fildvscf}1",
+                        ).as_posix(),
+                        Path("save", f"{prefix}.dvscf_q{iqpt}").as_posix(),
+                    )
+                )
                 # The following code was a first attempt to also deal with PAW pseudos. Currently not supported.
                 #
                 # remote_copy_list.append((
@@ -211,13 +254,15 @@ class EpwCalculation(CalcJob):
                 #     ).as_posix(),
                 #     Path('save', f"{prefix}.dvscf_paw_q{iqpt}").as_posix()
                 # ))
-                remote_list.append((
-                    parent_folder_ph.computer.uuid, Path(ph_path, f'{fildyn}{iqpt}').as_posix(),
-                    Path('save', f'{prefix}.dyn_q{iqpt}').as_posix()
-                ))
+                remote_list.append(
+                    (
+                        parent_folder_ph.computer.uuid,
+                        Path(ph_path, f"{fildyn}{iqpt}").as_posix(),
+                        Path("save", f"{prefix}.dyn_q{iqpt}").as_posix(),
+                    )
+                )
 
-        if 'parent_folder_epw' in self.inputs:
-
+        if "parent_folder_epw" in self.inputs:
             parent_folder_epw = self.inputs.parent_folder_epw
             if isinstance(parent_folder_epw, orm.RemoteStashFolderData):
                 epw_path = Path(parent_folder_epw.target_basepath)
@@ -225,128 +270,158 @@ class EpwCalculation(CalcJob):
                 epw_path = Path(parent_folder_epw.get_remote_path())
 
             vme_fmt_dict = {
-                'dipole': 'dmedata.fmt',
-                'wannier': 'vmedata.fmt',
+                "dipole": "dmedata.fmt",
+                "wannier": "vmedata.fmt",
             }
             file_list = [
-                'selecq.fmt', 'crystal.fmt', 'epwdata.fmt', vme_fmt_dict[parameters['INPUTEPW']['vme']],
-                f'{self._PREFIX}.kgmap', f'{self._PREFIX}.kmap', f'{self._PREFIX}.ukk', self._OUTPUT_SUBFOLDER,
-                self._FOLDER_SAVE
+                "selecq.fmt",
+                "crystal.fmt",
+                "epwdata.fmt",
+                vme_fmt_dict[parameters["INPUTEPW"]["vme"]],
+                f"{self._PREFIX}.kgmap",
+                f"{self._PREFIX}.kmap",
+                f"{self._PREFIX}.ukk",
+                self._OUTPUT_SUBFOLDER,
+                self._FOLDER_SAVE,
             ]
-            if parameters['INPUTEPW'].get('restart', False):
-                file_list.append('restart.fmt')
+            if parameters["INPUTEPW"].get("restart", False):
+                file_list.append("restart.fmt")
 
             for filename in file_list:
                 remote_list.append(
-                    (parent_folder_epw.computer.uuid, Path(epw_path, filename).as_posix(), Path(filename).as_posix())
+                    (
+                        parent_folder_epw.computer.uuid,
+                        Path(epw_path, filename).as_posix(),
+                        Path(filename).as_posix(),
+                    )
                 )
         # check if wannierize is True and if parent_folder_epw or parent_folder_chk is provided
-        wannierize = parameters['INPUTEPW'].get('wannierize', False)
+        wannierize = parameters["INPUTEPW"].get("wannierize", False)
 
         if wannierize and any(
-            _ in self.inputs
-            for _ in ["parent_folder_epw", "parent_folder_chk"]
+            _ in self.inputs for _ in ["parent_folder_epw", "parent_folder_chk"]
         ):
-            self.report("Should not have a parent folder of epw or chk if wannierize is True")
+            self.report(
+                "Should not have a parent folder of epw or chk if wannierize is True"
+            )
             return self.exit_codes.ERROR_PARAMETERS_NOT_VALID
-            
-        # check if nstemp is too large
-        nstemp = parameters['INPUTEPW'].get('nstemp', None)
-        if nstemp and nstemp > self._MAX_NSTEMP:
-            self.report(f'nstemp too large, reset it to maximum allowed: {self._MAX_NSTEMP}')
-            parameters['INPUTEPW']['nstemp'] = self._MAX_NSTEMP
 
-        parameters['INPUTEPW']['outdir'] = self._OUTPUT_SUBFOLDER
-        parameters['INPUTEPW']['dvscf_dir'] = self._FOLDER_SAVE
-        parameters['INPUTEPW']['prefix'] = self._PREFIX
+        # check if nstemp is too large
+        nstemp = parameters["INPUTEPW"].get("nstemp", None)
+        if nstemp and nstemp > self._MAX_NSTEMP:
+            self.report(
+                f"nstemp too large, reset it to maximum allowed: {self._MAX_NSTEMP}"
+            )
+            parameters["INPUTEPW"]["nstemp"] = self._MAX_NSTEMP
+
+        parameters["INPUTEPW"]["outdir"] = self._OUTPUT_SUBFOLDER
+        parameters["INPUTEPW"]["dvscf_dir"] = self._FOLDER_SAVE
+        parameters["INPUTEPW"]["prefix"] = self._PREFIX
 
         try:
             mesh, offset = self.inputs.qpoints.get_kpoints_mesh()
             test_offset(offset)
-            parameters['INPUTEPW']['nq1'] = mesh[0]
-            parameters['INPUTEPW']['nq2'] = mesh[1]
-            parameters['INPUTEPW']['nq3'] = mesh[2]
+            parameters["INPUTEPW"]["nq1"] = mesh[0]
+            parameters["INPUTEPW"]["nq2"] = mesh[1]
+            parameters["INPUTEPW"]["nq3"] = mesh[2]
         except NotImplementedError as exception:
-            raise exceptions.InputValidationError('Cannot get the coarse q-point grid') from exception
+            raise exceptions.InputValidationError(
+                "Cannot get the coarse q-point grid"
+            ) from exception
 
         try:
             mesh, offset = self.inputs.kpoints.get_kpoints_mesh()
             test_offset(offset)
-            parameters['INPUTEPW']['nk1'] = mesh[0]
-            parameters['INPUTEPW']['nk2'] = mesh[1]
-            parameters['INPUTEPW']['nk3'] = mesh[2]
+            parameters["INPUTEPW"]["nk1"] = mesh[0]
+            parameters["INPUTEPW"]["nk2"] = mesh[1]
+            parameters["INPUTEPW"]["nk3"] = mesh[2]
         except NotImplementedError as exception:
-            raise exceptions.InputValidationError('Cannot get the coarse k-point grid') from exception
+            raise exceptions.InputValidationError(
+                "Cannot get the coarse k-point grid"
+            ) from exception
 
         try:
             mesh, offset = self.inputs.qfpoints.get_kpoints_mesh()
             test_offset(offset)
-            parameters['INPUTEPW']['nqf1'] = mesh[0]
-            parameters['INPUTEPW']['nqf2'] = mesh[1]
-            parameters['INPUTEPW']['nqf3'] = mesh[2]
+            parameters["INPUTEPW"]["nqf1"] = mesh[0]
+            parameters["INPUTEPW"]["nqf2"] = mesh[1]
+            parameters["INPUTEPW"]["nqf3"] = mesh[2]
         except AttributeError:
             qfpoints = self.inputs.qfpoints.get_kpoints()
-            with folder.open(self._qfpoints_input_file, 'w') as handle:
-                handle.write(f'{len(qfpoints)} crystal\n')
+            with folder.open(self._qfpoints_input_file, "w") as handle:
+                handle.write(f"{len(qfpoints)} crystal\n")
                 for kpt in qfpoints:
-                    handle.write(' '.join([f'{coord:.12}' for coord in kpt]) + '   1.0\n')
-            parameters['INPUTEPW']['filqf'] = self._qfpoints_input_file
+                    handle.write(
+                        " ".join([f"{coord:.12}" for coord in kpt]) + "   1.0\n"
+                    )
+            parameters["INPUTEPW"]["filqf"] = self._qfpoints_input_file
         except NotImplementedError as exception:
-            raise exceptions.InputValidationError('Cannot get the fine q-point grid') from exception
+            raise exceptions.InputValidationError(
+                "Cannot get the fine q-point grid"
+            ) from exception
 
         try:
             mesh, offset = self.inputs.kfpoints.get_kpoints_mesh()
             test_offset(offset)
-            parameters['INPUTEPW']['nkf1'] = mesh[0]
-            parameters['INPUTEPW']['nkf2'] = mesh[1]
-            parameters['INPUTEPW']['nkf3'] = mesh[2]
+            parameters["INPUTEPW"]["nkf1"] = mesh[0]
+            parameters["INPUTEPW"]["nkf2"] = mesh[1]
+            parameters["INPUTEPW"]["nkf3"] = mesh[2]
         except AttributeError:
             kfpoints = self.inputs.kfpoints.get_kpoints()
-            with folder.open(self._kfpoints_input_file, 'w') as handle:
-                handle.write(f'{len(kfpoints)} crystal\n')
+            with folder.open(self._kfpoints_input_file, "w") as handle:
+                handle.write(f"{len(kfpoints)} crystal\n")
                 for kpt in kfpoints:
-                    handle.write(' '.join([f'{coord:.12}' for coord in kpt]) + '   1.0\n')
-            parameters['INPUTEPW']['filkf'] = self._kfpoints_input_file
+                    handle.write(
+                        " ".join([f"{coord:.12}" for coord in kpt]) + "   1.0\n"
+                    )
+            parameters["INPUTEPW"]["filkf"] = self._kfpoints_input_file
         except NotImplementedError as exception:
-            raise exceptions.InputValidationError('Cannot get the fine k-point grid') from exception
+            raise exceptions.InputValidationError(
+                "Cannot get the fine k-point grid"
+            ) from exception
 
-        if parameters['INPUTEPW'].get('band_plot'):
-            retrieve_list += ['band.eig', 'phband.freq']
+        if parameters["INPUTEPW"].get("band_plot"):
+            retrieve_list += ["band.eig", "phband.freq"]
 
-        if parameters['INPUTEPW'].get('laniso', False):
-            retrieve_list.append('aiida.imag_aniso_gap*')
+        if parameters["INPUTEPW"].get("laniso", False):
+            retrieve_list.append("aiida.imag_aniso_gap*")
 
         # customized namelists, otherwise not present in the distributed epw code
         try:
-            namelists_toprint = settings.pop('NAMELISTS')
+            namelists_toprint = settings.pop("NAMELISTS")
             if not isinstance(namelists_toprint, list):
                 raise exceptions.InputValidationError(
                     "The 'NAMELISTS' value, if specified in the settings input "
-                    'node, must be a list of strings'
+                    "node, must be a list of strings"
                 )
-        except KeyError:  # list of namelists not specified in the settings; do automatic detection
+        except (
+            KeyError
+        ):  # list of namelists not specified in the settings; do automatic detection
             namelists_toprint = self._compulsory_namelists
 
-        with folder.open(self.metadata.options.input_filename, 'w') as infile:
+        with folder.open(self.metadata.options.input_filename, "w") as infile:
             for namelist_name in namelists_toprint:
-                infile.write(f'&{namelist_name}\n')
+                infile.write(f"&{namelist_name}\n")
                 # namelist content; set to {} if not present, so that we leave an empty namelist
                 namelist = parameters.pop(namelist_name, {})
                 for key, value in sorted(namelist.items()):
                     inputs = convert_input_to_namelist_entry(key, value)
-                    if key == 'temps':
-                        inputs = inputs.replace("'", '')
+                    if key == "temps":
+                        inputs = inputs.replace("'", "")
                     infile.write(inputs)
-                infile.write('/\n')
+                infile.write("/\n")
 
         if parameters:
             raise exceptions.InputValidationError(
-                'The following namelists are specified in parameters, but are not valid namelists for the current type '
-                f'of calculation: {",".join(list(parameters.keys()))}'
+                "The following namelists are specified in parameters, but are not valid namelists for the current type "
+                f"of calculation: {','.join(list(parameters.keys()))}"
             )
 
         codeinfo = datastructures.CodeInfo()
-        codeinfo.cmdline_params = (list(settings.pop('CMDLINE', [])) + ['-in', self.metadata.options.input_filename])
+        codeinfo.cmdline_params = list(settings.pop("CMDLINE", [])) + [
+            "-in",
+            self.metadata.options.input_filename,
+        ]
         codeinfo.stdout_name = self.metadata.options.output_filename
         codeinfo.code_uuid = self.inputs.code.uuid
 
@@ -357,10 +432,12 @@ class EpwCalculation(CalcJob):
         calcinfo.remote_symlink_list = remote_symlink_list
 
         calcinfo.retrieve_list = retrieve_list
-        calcinfo.retrieve_list += settings.pop('ADDITIONAL_RETRIEVE_LIST', [])
+        calcinfo.retrieve_list += settings.pop("ADDITIONAL_RETRIEVE_LIST", [])
 
         if settings:
-            unknown_keys = ', '.join(list(settings.keys()))
-            raise exceptions.InputValidationError(f'`settings` contained unexpected keys: {unknown_keys}')
+            unknown_keys = ", ".join(list(settings.keys()))
+            raise exceptions.InputValidationError(
+                f"`settings` contained unexpected keys: {unknown_keys}"
+            )
 
         return calcinfo

--- a/src/aiida_epw/tools/calculators.py
+++ b/src/aiida_epw/tools/calculators.py
@@ -11,7 +11,11 @@ def allen_dynes(lambo, omega_log, mu_star):
     if lambo - mu_star * (1 + 0.62 * lambo) < 0:
         return 0
     else:
-        return omega_log * numpy.exp(-1.04 * (1 + lambo) / (lambo - mu_star * (1 + 0.62 * lambo))) / 1.2
+        return (
+            omega_log
+            * numpy.exp(-1.04 * (1 + lambo) / (lambo - mu_star * (1 + 0.62 * lambo)))
+            / 1.2
+        )
 
 
 def calculate_lambda_omega(frequency: ArrayLike, spectrum: ArrayLike) -> tuple:
@@ -23,11 +27,16 @@ def calculate_lambda_omega(frequency: ArrayLike, spectrum: ArrayLike) -> tuple:
     :returns: Tuple of the calculated lambda and omega_log values.
     """
     lambda_ = 2 * numpy.trapezoid(spectrum / frequency, frequency)  # unitless
-    omega_log = numpy.exp(2 / lambda_ * numpy.trapezoid(spectrum / frequency * numpy.log(frequency), frequency))  # eV
+    omega_log = numpy.exp(
+        2
+        / lambda_
+        * numpy.trapezoid(spectrum / frequency * numpy.log(frequency), frequency)
+    )  # eV
     omega_log = omega_log * meV_to_Kelvin
 
     return lambda_, omega_log
 
+
 # This function is taken from https://www.sciencedirect.com/science/article/pii/S0010465516302260 eq.81
 def bcs_gap_function(T, Tc, p, Delta_0):
-    return Delta_0 * numpy.sqrt(1 - (T/Tc)**p)
+    return Delta_0 * numpy.sqrt(1 - (T / Tc) ** p)

--- a/src/aiida_epw/tools/kpoints.py
+++ b/src/aiida_epw/tools/kpoints.py
@@ -1,15 +1,15 @@
 def check_kpoints_qpoints_compatibility(
     kpoints,
     qpoints,
-    ) -> tuple[bool, str ]:
+) -> tuple[bool, str]:
     """Check if the kpoints and qpoints are compatible."""
-    
+
     kpoints_mesh, kpoints_shift = kpoints.get_kpoints_mesh()
     qpoints_mesh, qpoints_shift = qpoints.get_kpoints_mesh()
-    
+
     multiplicities = []
     remainder = []
-    
+
     for k, q in zip(kpoints_mesh, qpoints_mesh):
         multiplicities.append(k // q)
         remainder.append(k % q)
@@ -18,6 +18,9 @@ def check_kpoints_qpoints_compatibility(
         return (False, "Shift grid is not supported.")
     else:
         if remainder == [0, 0, 0]:
-            return (True, f"The kpoints and qpoints are compatible with multiplicities {multiplicities}.")
+            return (
+                True,
+                f"The kpoints and qpoints are compatible with multiplicities {multiplicities}.",
+            )
         else:
             return (False, "The kpoints and qpoints are not compatible.")

--- a/src/aiida_epw/tools/parsers.py
+++ b/src/aiida_epw/tools/parsers.py
@@ -1,26 +1,29 @@
 """Manual parsing functions for post-processing."""
+
 import numpy
 
-Ry2eV =  13.605662285137
+Ry2eV = 13.605662285137
+
 
 def parse_epw_a2f(file_content):
-
     parsed_data = {}
 
-    a2f, footer = file_content.split('\n Integrated el-ph coupling')
+    a2f, footer = file_content.split("\n Integrated el-ph coupling")
 
-    a2f_array = numpy.array([l.split() for l in a2f.split('\n')], dtype=float)
-    parsed_data['frequency'] = a2f_array[:, 0]
-    parsed_data['a2f'] = a2f_array[:, 1:]
+    a2f_array = numpy.array([line.split() for line in a2f.split("\n")], dtype=float)
+    parsed_data["frequency"] = a2f_array[:, 0]
+    parsed_data["a2f"] = a2f_array[:, 1:]
 
-    footer = footer.split('\n')
-    parsed_data['lambda'] = numpy.array(footer[1].strip('# ').split(), dtype=float)
-    parsed_data['phonon_smearing'] = numpy.array(footer[3].strip('# ').split(), dtype=float)
+    footer = footer.split("\n")
+    parsed_data["lambda"] = numpy.array(footer[1].strip("# ").split(), dtype=float)
+    parsed_data["phonon_smearing"] = numpy.array(
+        footer[3].strip("# ").split(), dtype=float
+    )
 
     key_property_dict = {
-        'Electron smearing (eV)': 'electron_smearing',
-        'Fermi window (eV)': 'fermi_window',
-        'Summed el-ph coupling': 'summed_elph_coupling'
+        "Electron smearing (eV)": "electron_smearing",
+        "Fermi window (eV)": "fermi_window",
+        "Summed el-ph coupling": "summed_elph_coupling",
     }
     for line in footer:
         for key, property in key_property_dict.items():

--- a/src/aiida_epw/workflows/__init__.py
+++ b/src/aiida_epw/workflows/__init__.py
@@ -1,10 +1,11 @@
 """Workflows for the EPW code."""
+
 from .base import EpwBaseWorkChain
 from .prep import EpwPrepWorkChain
 from .supercon import SuperConWorkChain
 
 __all__ = [
-    'EpwBaseWorkChain',
-    'EpwPrepWorkChain',
-    'SuperConWorkChain',
+    "EpwBaseWorkChain",
+    "EpwPrepWorkChain",
+    "SuperConWorkChain",
 ]

--- a/src/aiida_epw/workflows/base.py
+++ b/src/aiida_epw/workflows/base.py
@@ -1,18 +1,26 @@
 # -*- coding: utf-8 -*-
 from aiida import orm
-from aiida.common import AttributeDict, NotExistent
+from aiida.common import AttributeDict
 
-from aiida.engine import BaseRestartWorkChain, ProcessHandlerReport, process_handler, while_
+from aiida.engine import (
+    BaseRestartWorkChain,
+    ProcessHandlerReport,
+    process_handler,
+    while_,
+)
 from aiida.plugins import CalculationFactory
 from aiida.common.lang import type_check
 
-from aiida_quantumespresso.calculations.functions.create_kpoints_from_distance import create_kpoints_from_distance
+from aiida_quantumespresso.calculations.functions.create_kpoints_from_distance import (
+    create_kpoints_from_distance,
+)
 from aiida_quantumespresso.workflows.protocols.utils import ProtocolMixin
 from aiida.orm.nodes.data.base import to_aiida_type
 
 from aiida_epw.tools.kpoints import check_kpoints_qpoints_compatibility
 
-EpwCalculation = CalculationFactory('epw.epw')
+EpwCalculation = CalculationFactory("epw.epw")
+
 
 def get_kpoints_from_chk_folder(chk_folder):
     """
@@ -25,52 +33,43 @@ def get_kpoints_from_chk_folder(chk_folder):
 
     wannier_params = chk_folder.creator.inputs.parameters
 
-    if 'mp_grid' in wannier_params:
-        mp_grid = wannier_params['mp_grid']
+    if "mp_grid" in wannier_params:
+        mp_grid = wannier_params["mp_grid"]
         kpoints = orm.KpointsData()
         kpoints.set_kpoints_mesh(mp_grid)
         return kpoints
     else:
-        raise ValueError("Could not deduce mesh from the parent folder of the nscf calculation.")
-            
+        raise ValueError(
+            "Could not deduce mesh from the parent folder of the nscf calculation."
+        )
+
+
 def validate_inputs(  # pylint: disable=unused-argument,inconsistent-return-statements
     inputs, ctx=None
-    ):
+):
     """Validate the inputs of the entire input namespace of `EpwBaseWorkChain`."""
     # Usually at the creation of the inputs, the coarse and fine k/q grid is already determined.
-    # 
+    #
     # Cannot specify both `kfpoints` and `kfpoints_factor`
-    if (
-        all(
-            _ in inputs
-            for _ in ["kfpoints", "kfpoints_factor"]
-        )
-    ):
+    if all(_ in inputs for _ in ["kfpoints", "kfpoints_factor"]):
         return "Can only specify one of the `kfpoints`, `kfpoints_factor`."
 
-    if not any(
-        [_ in inputs for _ in ["kfpoints", "kfpoints_factor"]]
-        ):
+    if not any([_ in inputs for _ in ["kfpoints", "kfpoints_factor"]]):
         return "Either `kfpoints` or `kfpoints_factor` must be specified."
 
     # Cannot specify both `kfpoints` and `kfpoints_factor`
-    if (
-        all(
-            _ in inputs
-            for _ in ["qfpoints", "qfpoints_distance"]
-        )
-    ):
+    if all(_ in inputs for _ in ["qfpoints", "qfpoints_distance"]):
         return "Can only specify one of the `qfpoints`, `qfpoints_distance`."
 
-    if not any(
-        [_ in inputs for _ in ["qfpoints", "qfpoints_distance"]]
-        ):
+    if not any([_ in inputs for _ in ["qfpoints", "qfpoints_distance"]]):
         return "Either `qfpoints` or `qfpoints_distance` must be specified."
 
     return None
 
+
 class EpwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
     """BaseWorkchain to run a epw.x calculation."""
+
     _process_class = EpwCalculation
 
     @classmethod
@@ -159,14 +158,15 @@ class EpwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
             message='The calculation failed with an unidentified unrecoverable error.')
         spec.exit_code(310, 'ERROR_KNOWN_UNRECOVERABLE_FAILURE',
             message='The calculation failed with a known unrecoverable error.')
-    
+
     @classmethod
     def get_protocol_filepath(cls):
         """Return ``pathlib.Path`` to the ``.yaml`` file that defines the protocols."""
         from importlib_resources import files
 
         from . import protocols
-        return files(protocols) / 'base.yaml'
+
+        return files(protocols) / "base.yaml"
 
     @classmethod
     def get_builder_from_protocol(
@@ -177,8 +177,8 @@ class EpwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         overrides=None,
         options=None,
         w90_chk_to_ukk_script=None,
-        **_
-        ):
+        **_,
+    ):
         """Return a builder prepopulated with inputs selected according to the chosen protocol.
 
         :param code: the ``Code`` instance configured for the ``quantumespresso.epw`` plugin.
@@ -191,21 +191,21 @@ class EpwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
 
         type_check(code, orm.Code)
         type_check(structure, orm.StructureData)
-        
+
         inputs = cls.get_protocol_inputs(protocol, overrides)
 
         # Update the parameters based on the protocol inputs
-        parameters = inputs['parameters']
+        parameters = inputs["parameters"]
 
         # If overrides are provided, they are considered absolute
         if overrides:
-            parameter_overrides = overrides.get('parameters', {})
+            parameter_overrides = overrides.get("parameters", {})
             parameters = recursive_merge(parameters, parameter_overrides)
 
-        metadata = inputs.pop('metadata')
+        metadata = inputs.pop("metadata")
 
         if options:
-            metadata['options'] = recursive_merge(metadata['options'], options)
+            metadata["options"] = recursive_merge(metadata["options"], options)
 
         # pylint: disable=no-member
         builder = cls.get_builder()
@@ -213,22 +213,22 @@ class EpwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         builder.code = code
         builder.parameters = orm.Dict(parameters)
         ## Must firstly pop the options from the metadata dictionary.
-        builder.options = metadata.pop('options')
+        builder.options = metadata.pop("options")
 
         if w90_chk_to_ukk_script:
             type_check(w90_chk_to_ukk_script, orm.RemoteData)
             builder.w90_chk_to_ukk_script = w90_chk_to_ukk_script
 
-        if 'settings' in inputs:
-            builder.settings = orm.Dict(inputs['settings'])
-        if 'parallelization' in inputs:
-            builder.parallelization = orm.Dict(inputs['parallelization'])
+        if "settings" in inputs:
+            builder.settings = orm.Dict(inputs["settings"])
+        if "parallelization" in inputs:
+            builder.parallelization = orm.Dict(inputs["parallelization"])
 
-        builder.clean_workdir = orm.Bool(inputs['clean_workdir'])
+        builder.clean_workdir = orm.Bool(inputs["clean_workdir"])
 
-        builder.qfpoints_distance = orm.Float(inputs['qfpoints_distance'])
-        builder.kfpoints_factor = orm.Int(inputs['kfpoints_factor'])
-        builder.max_iterations = orm.Int(inputs['max_iterations'])
+        builder.qfpoints_distance = orm.Float(inputs["qfpoints_distance"])
+        builder.kfpoints_factor = orm.Int(inputs["kfpoints_factor"])
+        builder.max_iterations = orm.Int(inputs["max_iterations"])
         # pylint: enable=no-member
 
         return builder
@@ -239,26 +239,27 @@ class EpwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         """
         super().setup()
 
-        self.ctx.inputs = AttributeDict(
-            self.exposed_inputs(EpwCalculation)
-        )
+        self.ctx.inputs = AttributeDict(self.exposed_inputs(EpwCalculation))
 
         # Initialize here an empty metadata dictionary.
         # Now there is only options in it.
-        
+
         # TODO: Should check if we need to append more
         # information into it.
         metadata = {}
 
-        metadata['options'] = self.inputs.options.get_dict()
+        metadata["options"] = self.inputs.options.get_dict()
 
         ## Didn't find the way to modify `metadata` in EpwCalculation.
         ## It should be migrated into EpwCalculation in the future.
-        if 'w90_chk_to_ukk_script' in self.inputs and 'parent_folder_chk' in self.inputs:
-            prepend_text = metadata['options'].get('prepend_text', '')
-            prepend_text += f'\n{self.inputs.w90_chk_to_ukk_script.get_remote_path()} {EpwCalculation._PREFIX}.chk {EpwCalculation._OUTPUT_SUBFOLDER}{EpwCalculation._PREFIX}.xml {EpwCalculation._PREFIX}.ukk {EpwCalculation._PREFIX}.wannier90.mmn {EpwCalculation._PREFIX}.mmn'
+        if (
+            "w90_chk_to_ukk_script" in self.inputs
+            and "parent_folder_chk" in self.inputs
+        ):
+            prepend_text = metadata["options"].get("prepend_text", "")
+            prepend_text += f"\n{self.inputs.w90_chk_to_ukk_script.get_remote_path()} {EpwCalculation._PREFIX}.chk {EpwCalculation._OUTPUT_SUBFOLDER}{EpwCalculation._PREFIX}.xml {EpwCalculation._PREFIX}.ukk {EpwCalculation._PREFIX}.wannier90.mmn {EpwCalculation._PREFIX}.mmn"
 
-            metadata['options']['prepend_text'] = prepend_text
+            metadata["options"]["prepend_text"] = prepend_text
 
         self.ctx.inputs.metadata = metadata
 
@@ -268,22 +269,32 @@ class EpwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         # the EpwBaseWorkChain and the parameters inside EpwCalculation are not the same.
         parameters = self.ctx.inputs.parameters.get_dict()
 
-        if 'parent_folder_chk' in self.inputs:
-            w90_params = self.inputs.parent_folder_chk.creator.inputs.parameters.get_dict()
-            exclude_bands = w90_params.get('exclude_bands', None) #TODO check this!
+        if "parent_folder_chk" in self.inputs:
+            w90_params = (
+                self.inputs.parent_folder_chk.creator.inputs.parameters.get_dict()
+            )
+            exclude_bands = w90_params.get("exclude_bands", None)  # TODO check this!
 
             if exclude_bands:
-                parameters['INPUTEPW']['bands_skipped'] = f'exclude_bands = {exclude_bands[0]}:{exclude_bands[-1]}'
+                parameters["INPUTEPW"]["bands_skipped"] = (
+                    f"exclude_bands = {exclude_bands[0]}:{exclude_bands[-1]}"
+                )
 
-            parameters['INPUTEPW']['nbndsub'] = w90_params['num_wann']
+            parameters["INPUTEPW"]["nbndsub"] = w90_params["num_wann"]
 
-        if 'parent_folder_epw' in self.inputs:
-            epw_params = self.inputs.parent_folder_epw.creator.inputs.parameters.get_dict()
-            parameters['INPUTEPW']['use_ws'] = epw_params['INPUTEPW'].get("use_ws", False)
-            parameters['INPUTEPW']['nbndsub'] = epw_params['INPUTEPW']['nbndsub']
-            if 'bands_skipped' in epw_params['INPUTEPW']:
-                parameters['INPUTEPW']['bands_skipped'] = epw_params['INPUTEPW'].get('bands_skipped')
-        
+        if "parent_folder_epw" in self.inputs:
+            epw_params = (
+                self.inputs.parent_folder_epw.creator.inputs.parameters.get_dict()
+            )
+            parameters["INPUTEPW"]["use_ws"] = epw_params["INPUTEPW"].get(
+                "use_ws", False
+            )
+            parameters["INPUTEPW"]["nbndsub"] = epw_params["INPUTEPW"]["nbndsub"]
+            if "bands_skipped" in epw_params["INPUTEPW"]:
+                parameters["INPUTEPW"]["bands_skipped"] = epw_params["INPUTEPW"].get(
+                    "bands_skipped"
+                )
+
         self.ctx.inputs.parameters = orm.Dict(parameters)
 
     # We should validate the kpoints and qpoints on the fly
@@ -301,64 +312,73 @@ class EpwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         # If there is already the parent folder of a previous EPW calculation, the coarse k/q grid is already there and must be valid.
         # We only need to take the kpointsdata from it and continue to generate the find grid.
 
-        if 'parent_folder_epw' in self.inputs:
+        if "parent_folder_epw" in self.inputs:
             epw_calc = self.inputs.parent_folder_epw.creator
             kpoints = epw_calc.inputs.kpoints
             qpoints = epw_calc.inputs.qpoints
 
         # If there is no parent folder of a previous EPW calculation, it must be the case that we are running the transition from coarse BLoch representation to Wannier representation.
-        # This means that we are using coarse k grid from a previous nscf calculation and 
+        # This means that we are using coarse k grid from a previous nscf calculation and
         else:
-            if 'kpoints' in self.inputs:
+            if "kpoints" in self.inputs:
                 kpoints = self.inputs.kpoints
-            elif 'parent_folder_chk' in self.inputs:
+            elif "parent_folder_chk" in self.inputs:
                 kpoints = get_kpoints_from_chk_folder(self.inputs.parent_folder_chk)
             else:
-                self.report("Could not determine the coarse k-points from the inputs or the parent folder of the wannier90 calculation.")
+                self.report(
+                    "Could not determine the coarse k-points from the inputs or the parent folder of the wannier90 calculation."
+                )
                 return self.exit_codes.ERROR_COARSE_GRID_NOT_VALID
-            
-            if 'qpoints' in self.inputs:
+
+            if "qpoints" in self.inputs:
                 qpoints = self.inputs.qpoints
-            elif 'parent_folder_ph' in self.inputs:
+            elif "parent_folder_ph" in self.inputs:
                 qpoints = self.inputs.parent_folder_ph.creator.inputs.qpoints
             else:
-                self.report("Could not determine the coarse q-points from the inputs or the parent folder of the ph calculation.")
+                self.report(
+                    "Could not determine the coarse q-points from the inputs or the parent folder of the ph calculation."
+                )
                 return self.exit_codes.ERROR_COARSE_GRID_NOT_VALID
-            
-        self.report(f"Successfully determined coarse k-points from the inputs: {kpoints.get_kpoints_mesh()[0]}")
-        self.report(f"Successfully determined coarse q-points from the inputs: {qpoints.get_kpoints_mesh()[0]}")
 
+        self.report(
+            f"Successfully determined coarse k-points from the inputs: {kpoints.get_kpoints_mesh()[0]}"
+        )
+        self.report(
+            f"Successfully determined coarse q-points from the inputs: {qpoints.get_kpoints_mesh()[0]}"
+        )
 
         is_compatible, message = check_kpoints_qpoints_compatibility(kpoints, qpoints)
-        
+
         self.ctx.inputs.kpoints = kpoints
         self.ctx.inputs.qpoints = qpoints
-        
+
         if not is_compatible:
             self.report(message)
             return self.exit_codes.ERROR_COARSE_GRID_NOT_VALID
 
         ## TODO: If we are restarting from .ephmat folder, we should use the same
         ## qfpoints and kfpoints as the creator of 'parent_folder_epw'.
-        if 'qfpoints' in self.inputs:
+        if "qfpoints" in self.inputs:
             qfpoints = self.inputs.qfpoints
         else:
             inputs = {
-                'structure': self.inputs.structure,
-                'distance': self.inputs.qfpoints_distance,
-                'force_parity': self.inputs.get('qfpoints_force_parity', orm.Bool(False)),
-                'metadata': {
-                    'call_link_label': 'create_qfpoints_from_distance'
-                }
+                "structure": self.inputs.structure,
+                "distance": self.inputs.qfpoints_distance,
+                "force_parity": self.inputs.get(
+                    "qfpoints_force_parity", orm.Bool(False)
+                ),
+                "metadata": {"call_link_label": "create_qfpoints_from_distance"},
             }
             qfpoints = create_kpoints_from_distance(**inputs)  # pylint: disable=unexpected-keyword-arg
 
-        if 'kfpoints' in self.inputs:
+        if "kfpoints" in self.inputs:
             kfpoints = self.inputs.kfpoints
         else:
             qfpoints_mesh = qfpoints.get_kpoints_mesh()[0]
             kfpoints = orm.KpointsData()
-            kfpoints.set_kpoints_mesh([v * self.inputs.kfpoints_factor.value for v in qfpoints_mesh])
+            kfpoints.set_kpoints_mesh(
+                [v * self.inputs.kfpoints_factor.value for v in qfpoints_mesh]
+            )
 
         self.ctx.inputs.qfpoints = qfpoints
         self.ctx.inputs.kfpoints = kfpoints
@@ -380,13 +400,20 @@ class EpwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         :param calculation: the failed calculation node
         :param action: a string message with the action taken
         """
-        arguments = [calculation.process_label, calculation.pk, calculation.exit_status, calculation.exit_message]
-        self.report('{}<{}> failed with exit status {}: {}'.format(*arguments))
-        self.report(f'Action taken: {action}')
+        arguments = [
+            calculation.process_label,
+            calculation.pk,
+            calculation.exit_status,
+            calculation.exit_message,
+        ]
+        self.report("{}<{}> failed with exit status {}: {}".format(*arguments))
+        self.report(f"Action taken: {action}")
 
     @process_handler(priority=600)
     def handle_unrecoverable_failure(self, calculation):
         """Handle calculations with an exit status below 400 which are unrecoverable, so abort the work chain."""
         if calculation.is_failed and calculation.exit_status < 400:
-            self.report_error_handled(calculation, 'unrecoverable error, aborting...')
-            return ProcessHandlerReport(True, self.exit_codes.ERROR_UNRECOVERABLE_FAILURE)
+            self.report_error_handled(calculation, "unrecoverable error, aborting...")
+            return ProcessHandlerReport(
+                True, self.exit_codes.ERROR_UNRECOVERABLE_FAILURE
+            )

--- a/src/aiida_epw/workflows/prep.py
+++ b/src/aiida_epw/workflows/prep.py
@@ -1,21 +1,30 @@
 """Work chain for doing the coarse-grid calculations."""
+
 from pathlib import Path
 
 from aiida import orm
 from aiida.common import AttributeDict
 
-from aiida.engine import WorkChain, ToContext, if_
+from aiida.engine import WorkChain, ToContext
 from aiida_quantumespresso.workflows.ph.base import PhBaseWorkChain
 from aiida_quantumespresso.workflows.protocols.utils import ProtocolMixin
 
-from aiida_quantumespresso.calculations.functions.create_kpoints_from_distance import create_kpoints_from_distance
+from aiida_quantumespresso.calculations.functions.create_kpoints_from_distance import (
+    create_kpoints_from_distance,
+)
 
-from aiida_wannier90_workflows.workflows import Wannier90BandsWorkChain, Wannier90OptimizeWorkChain
-from aiida_wannier90_workflows.workflows.bands import validate_inputs as validate_inputs_bands
+from aiida_wannier90_workflows.workflows import (
+    Wannier90BandsWorkChain,
+    Wannier90OptimizeWorkChain,
+)
+from aiida_wannier90_workflows.workflows.bands import (
+    validate_inputs as validate_inputs_bands,
+)
 from aiida_wannier90_workflows.utils.workflows.builder.setter import set_kpoints
 from aiida_wannier90_workflows.common.types import WannierProjectionType
 
 from aiida_epw.workflows.base import EpwBaseWorkChain
+
 
 class EpwPrepWorkChain(ProtocolMixin, WorkChain):
     """Main work chain to start calculating properties using EPW.
@@ -29,52 +38,72 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
         """Define the work chain specification."""
         super().define(spec)
 
-        spec.input('structure', valid_type=orm.StructureData)
-        spec.input('clean_workdir', valid_type=orm.Bool, default=lambda: orm.Bool(False))
-        spec.input('qpoints_distance', valid_type=orm.Float, default=lambda: orm.Float(0.5))
-        spec.input('kpoints_distance_scf', valid_type=orm.Float, default=lambda: orm.Float(0.15))
-        spec.input('kpoints_factor_nscf', valid_type=orm.Int, default=lambda: orm.Int(2))
-        spec.input('w90_chk_to_ukk_script', valid_type=(orm.RemoteData, orm.SinglefileData))
-
-        spec.expose_inputs(
-            Wannier90OptimizeWorkChain, namespace='w90_bands', exclude=(
-                'structure', 'clean_workdir',
-            ),
-            namespace_options={
-                'help': 'Inputs for the `Wannier90OptimizeWorkChain/Wannier90BandsWorkChain`.'
-            }
+        spec.input("structure", valid_type=orm.StructureData)
+        spec.input(
+            "clean_workdir", valid_type=orm.Bool, default=lambda: orm.Bool(False)
         )
-        spec.inputs['w90_bands'].validator = validate_inputs_bands
-        spec.expose_inputs(
-            PhBaseWorkChain, namespace='ph_base', exclude=(
-                'clean_workdir', 'ph.parent_folder', 'qpoints', 'qpoints_distance'
-            ),
-            namespace_options={
-                'help': 'Inputs for the `PhBaseWorkChain` that does the `ph.x` calculation.'
-            }
+        spec.input(
+            "qpoints_distance", valid_type=orm.Float, default=lambda: orm.Float(0.5)
         )
-        spec.expose_inputs(
-            EpwBaseWorkChain, namespace='epw_base', exclude=(
-                'structure',
-                'clean_workdir',
-                'kpoints', 
-                'qpoints', 
-                'kfpoints', 
-                'qfpoints', 
-                'qfpoints_distance', 
-                'kfpoints_factor', 
-                'parent_folder_ph',
-                'parent_folder_nscf', 
-                'parent_folder_epw',
-                'parent_folder_chk'
-            ),
-            namespace_options={
-                'help': 'Inputs for the `EpwBaseWorkChain`.'
-            }
+        spec.input(
+            "kpoints_distance_scf",
+            valid_type=orm.Float,
+            default=lambda: orm.Float(0.15),
+        )
+        spec.input(
+            "kpoints_factor_nscf", valid_type=orm.Int, default=lambda: orm.Int(2)
+        )
+        spec.input(
+            "w90_chk_to_ukk_script", valid_type=(orm.RemoteData, orm.SinglefileData)
         )
 
-        spec.output('retrieved', valid_type=orm.FolderData)
-        spec.output('epw_folder', valid_type=orm.RemoteStashFolderData)
+        spec.expose_inputs(
+            Wannier90OptimizeWorkChain,
+            namespace="w90_bands",
+            exclude=(
+                "structure",
+                "clean_workdir",
+            ),
+            namespace_options={
+                "help": "Inputs for the `Wannier90OptimizeWorkChain/Wannier90BandsWorkChain`."
+            },
+        )
+        spec.inputs["w90_bands"].validator = validate_inputs_bands
+        spec.expose_inputs(
+            PhBaseWorkChain,
+            namespace="ph_base",
+            exclude=(
+                "clean_workdir",
+                "ph.parent_folder",
+                "qpoints",
+                "qpoints_distance",
+            ),
+            namespace_options={
+                "help": "Inputs for the `PhBaseWorkChain` that does the `ph.x` calculation."
+            },
+        )
+        spec.expose_inputs(
+            EpwBaseWorkChain,
+            namespace="epw_base",
+            exclude=(
+                "structure",
+                "clean_workdir",
+                "kpoints",
+                "qpoints",
+                "kfpoints",
+                "qfpoints",
+                "qfpoints_distance",
+                "kfpoints_factor",
+                "parent_folder_ph",
+                "parent_folder_nscf",
+                "parent_folder_epw",
+                "parent_folder_chk",
+            ),
+            namespace_options={"help": "Inputs for the `EpwBaseWorkChain`."},
+        )
+
+        spec.output("retrieved", valid_type=orm.FolderData)
+        spec.output("epw_folder", valid_type=orm.RemoteStashFolderData)
 
         spec.outline(
             cls.generate_reciprocal_points,
@@ -86,25 +115,42 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
             cls.inspect_epw,
             cls.results,
         )
-        spec.exit_code(403, 'ERROR_SUB_PROCESS_FAILED_PHONON',
-            message='The electron-phonon `PhBaseWorkChain` sub process failed')
-        spec.exit_code(404, 'ERROR_SUB_PROCESS_FAILED_WANNIER90',
-            message='The `Wannier90BandsWorkChain` sub process failed')
-        spec.exit_code(405, 'ERROR_SUB_PROCESS_FAILED_EPW',
-            message='The `EpwWorkChain` sub process failed')
+        spec.exit_code(
+            403,
+            "ERROR_SUB_PROCESS_FAILED_PHONON",
+            message="The electron-phonon `PhBaseWorkChain` sub process failed",
+        )
+        spec.exit_code(
+            404,
+            "ERROR_SUB_PROCESS_FAILED_WANNIER90",
+            message="The `Wannier90BandsWorkChain` sub process failed",
+        )
+        spec.exit_code(
+            405,
+            "ERROR_SUB_PROCESS_FAILED_EPW",
+            message="The `EpwWorkChain` sub process failed",
+        )
 
     @classmethod
     def get_protocol_filepath(cls):
         """Return ``pathlib.Path`` to the ``.yaml`` file that defines the protocols."""
         from importlib_resources import files
         from . import protocols
-        return files(protocols) / 'prep.yaml'
+
+        return files(protocols) / "prep.yaml"
 
     @classmethod
-    def get_builder_from_protocol(cls, codes, structure, protocol=None, overrides=None,
-                                  wannier_projection_type=WannierProjectionType.ATOMIC_PROJECTORS_QE,
-                                  reference_bands=None, bands_kpoints=None,
-                                  **kwargs):
+    def get_builder_from_protocol(
+        cls,
+        codes,
+        structure,
+        protocol=None,
+        overrides=None,
+        wannier_projection_type=WannierProjectionType.ATOMIC_PROJECTORS_QE,
+        reference_bands=None,
+        bands_kpoints=None,
+        **kwargs,
+    ):
         """Return a builder prepopulated with inputs selected according to the chosen protocol.
 
         :param structure: the ``StructureData`` instance to use.
@@ -119,12 +165,14 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
         builder = cls.get_builder()
         builder.structure = structure
 
-        w90_bands_inputs = inputs.get('w90_bands', {})
-        pseudo_family = w90_bands_inputs.pop('pseudo_family', None)
+        w90_bands_inputs = inputs.get("w90_bands", {})
+        pseudo_family = w90_bands_inputs.pop("pseudo_family", None)
 
         if wannier_projection_type == WannierProjectionType.ATOMIC_PROJECTORS_QE:
             if reference_bands is None:
-                raise ValueError(f'reference_bands must be specified for {wannier_projection_type}')
+                raise ValueError(
+                    f"reference_bands must be specified for {wannier_projection_type}"
+                )
             w90_bands = Wannier90OptimizeWorkChain.get_builder_from_protocol(
                 structure=structure,
                 codes=codes,
@@ -145,53 +193,66 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
                 overrides=w90_bands_inputs,
             )
         else:
-            raise ValueError(f'Unsupported wannier_projection_type: {wannier_projection_type}')
+            raise ValueError(
+                f"Unsupported wannier_projection_type: {wannier_projection_type}"
+            )
 
-        w90_bands.pop('structure', None)
-        w90_bands.pop('open_grid', None)
+        w90_bands.pop("structure", None)
+        w90_bands.pop("open_grid", None)
 
         builder.w90_bands = w90_bands
 
-        args = (codes['ph'], None, protocol)
-        ph_base = PhBaseWorkChain.get_builder_from_protocol(*args, overrides=inputs.get('ph_base', None), **kwargs)
-        ph_base.pop('clean_workdir', None)
-        ph_base.pop('qpoints_distance')
+        args = (codes["ph"], None, protocol)
+        ph_base = PhBaseWorkChain.get_builder_from_protocol(
+            *args, overrides=inputs.get("ph_base", None), **kwargs
+        )
+        ph_base.pop("clean_workdir", None)
+        ph_base.pop("qpoints_distance")
 
         builder.ph_base = ph_base
 
         # TODO: Here I have a loop for the epw builders for future extension of another epw bands interpolation
-        for namespace in ['epw_base',]:
+        for namespace in [
+            "epw_base",
+        ]:
             epw_inputs = inputs.get(namespace, None)
-            if namespace == 'epw_base':
-                if 'target_base' not in epw_inputs['metadata']['options']['stash']:
-                    epw_computer = codes['epw'].computer
-                    if epw_computer.transport_type == 'core.local':
-                        target_basepath = Path(epw_computer.get_workdir(), 'stash').as_posix()
-                    elif epw_computer.transport_type == 'core.ssh':
+            if namespace == "epw_base":
+                if "target_base" not in epw_inputs["metadata"]["options"]["stash"]:
+                    epw_computer = codes["epw"].computer
+                    if epw_computer.transport_type == "core.local":
                         target_basepath = Path(
-                            epw_computer.get_workdir().format(username=epw_computer.get_configuration()['username']), 'stash'
+                            epw_computer.get_workdir(), "stash"
                         ).as_posix()
-                    
-                    epw_inputs['metadata']['options']['stash']['target_base'] = target_basepath
+                    elif epw_computer.transport_type == "core.ssh":
+                        target_basepath = Path(
+                            epw_computer.get_workdir().format(
+                                username=epw_computer.get_configuration()["username"]
+                            ),
+                            "stash",
+                        ).as_posix()
+
+                    epw_inputs["metadata"]["options"]["stash"]["target_base"] = (
+                        target_basepath
+                    )
 
             epw_builder = EpwBaseWorkChain.get_builder_from_protocol(
-                code=codes['epw'],
+                code=codes["epw"],
                 structure=structure,
                 protocol=protocol,
                 overrides=epw_inputs,
-                **kwargs
+                **kwargs,
             )
 
-            if 'settings' in epw_inputs:
-                epw_builder.settings = orm.Dict(epw_inputs['settings'])
-            if 'parallelization' in epw_inputs:
-                epw_builder.parallelization = orm.Dict(epw_inputs['parallelization'])
+            if "settings" in epw_inputs:
+                epw_builder.settings = orm.Dict(epw_inputs["settings"])
+            if "parallelization" in epw_inputs:
+                epw_builder.parallelization = orm.Dict(epw_inputs["parallelization"])
             builder[namespace] = epw_builder
 
-        builder.qpoints_distance = orm.Float(inputs['qpoints_distance'])
-        builder.kpoints_distance_scf = orm.Float(inputs['kpoints_distance_scf'])
-        builder.kpoints_factor_nscf = orm.Int(inputs['kpoints_factor_nscf'])
-        builder.clean_workdir = orm.Bool(inputs['clean_workdir'])
+        builder.qpoints_distance = orm.Float(inputs["qpoints_distance"])
+        builder.kpoints_distance_scf = orm.Float(inputs["kpoints_distance_scf"])
+        builder.kpoints_factor_nscf = orm.Int(inputs["kpoints_factor_nscf"])
+        builder.clean_workdir = orm.Bool(inputs["clean_workdir"])
 
         return builder
 
@@ -199,27 +260,25 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
         """Generate the qpoints and kpoints meshes for the `ph.x` and `pw.x` calculations."""
 
         inputs = {
-            'structure': self.inputs.structure,
-            'distance': self.inputs.qpoints_distance,
-            'force_parity': self.inputs.get('kpoints_force_parity', orm.Bool(False)),
-            'metadata': {
-                'call_link_label': 'create_qpoints_from_distance'
-            }
+            "structure": self.inputs.structure,
+            "distance": self.inputs.qpoints_distance,
+            "force_parity": self.inputs.get("kpoints_force_parity", orm.Bool(False)),
+            "metadata": {"call_link_label": "create_qpoints_from_distance"},
         }
         qpoints = create_kpoints_from_distance(**inputs)  # pylint: disable=unexpected-keyword-arg
         inputs = {
-            'structure': self.inputs.structure,
-            'distance': self.inputs.kpoints_distance_scf,
-            'force_parity': self.inputs.get('kpoints_force_parity', orm.Bool(False)),
-            'metadata': {
-                'call_link_label': 'create_kpoints_scf_from_distance'
-            }
+            "structure": self.inputs.structure,
+            "distance": self.inputs.kpoints_distance_scf,
+            "force_parity": self.inputs.get("kpoints_force_parity", orm.Bool(False)),
+            "metadata": {"call_link_label": "create_kpoints_scf_from_distance"},
         }
         kpoints_scf = create_kpoints_from_distance(**inputs)
 
         qpoints_mesh = qpoints.get_kpoints_mesh()[0]
         kpoints_nscf = orm.KpointsData()
-        kpoints_nscf.set_kpoints_mesh([v * self.inputs.kpoints_factor_nscf.value for v in qpoints_mesh])
+        kpoints_nscf.set_kpoints_mesh(
+            [v * self.inputs.kpoints_factor_nscf.value for v in qpoints_mesh]
+        )
 
         self.ctx.qpoints = qpoints
         self.ctx.kpoints_scf = kpoints_scf
@@ -227,25 +286,25 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
 
     def run_wannier90(self):
         """Run the wannier90 workflow."""
-        if 'projwfc' in self.inputs.w90_bands:
+        if "projwfc" in self.inputs.w90_bands:
             w90_class = Wannier90BandsWorkChain
         else:
             w90_class = Wannier90OptimizeWorkChain
 
         self.ctx.w90_class_name = w90_class.get_name()
-        self.report(f'Running a {self.ctx.w90_class_name}.')
-        
+        self.report(f"Running a {self.ctx.w90_class_name}.")
+
         inputs = AttributeDict(
-            self.exposed_inputs(Wannier90OptimizeWorkChain, namespace='w90_bands')
+            self.exposed_inputs(Wannier90OptimizeWorkChain, namespace="w90_bands")
         )
-        inputs.metadata.call_link_label = 'w90_bands'
+        inputs.metadata.call_link_label = "w90_bands"
         inputs.structure = self.inputs.structure
 
         set_kpoints(inputs, self.ctx.kpoints_nscf, w90_class)
-        inputs['scf']['kpoints'] = self.ctx.kpoints_scf
+        inputs["scf"]["kpoints"] = self.ctx.kpoints_scf
 
         workchain_node = self.submit(w90_class, **inputs)
-        self.report(f'launching {w90_class.get_name()}<{workchain_node.pk}>')
+        self.report(f"launching {w90_class.get_name()}<{workchain_node.pk}>")
 
         return ToContext(workchain_w90_bands=workchain_node)
 
@@ -254,21 +313,31 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
         workchain = self.ctx.workchain_w90_bands
 
         if not workchain.is_finished_ok:
-            self.report(f'{self.ctx.w90_class_name}<{workchain.pk}> failed with exit status {workchain.exit_status}')
+            self.report(
+                f"{self.ctx.w90_class_name}<{workchain.pk}> failed with exit status {workchain.exit_status}"
+            )
             return self.exit_codes.ERROR_SUB_PROCESS_FAILED_WANNIER90
 
     def run_ph(self):
         """Run the `PhBaseWorkChain`."""
-        inputs = AttributeDict(self.exposed_inputs(PhBaseWorkChain, namespace='ph_base'))
+        inputs = AttributeDict(
+            self.exposed_inputs(PhBaseWorkChain, namespace="ph_base")
+        )
 
-        scf_base_wc = self.ctx.workchain_w90_bands.base.links.get_outgoing(link_label_filter='scf').first().node
+        scf_base_wc = (
+            self.ctx.workchain_w90_bands.base.links.get_outgoing(
+                link_label_filter="scf"
+            )
+            .first()
+            .node
+        )
         inputs.ph.parent_folder = scf_base_wc.outputs.remote_folder
 
         inputs.qpoints = self.ctx.qpoints
 
-        inputs.metadata.call_link_label = 'ph_base'
+        inputs.metadata.call_link_label = "ph_base"
         workchain_node = self.submit(PhBaseWorkChain, **inputs)
-        self.report(f'launching PhBaseWorkChain<{workchain_node.pk}>')
+        self.report(f"launching PhBaseWorkChain<{workchain_node.pk}>")
 
         return ToContext(workchain_ph=workchain_node)
 
@@ -277,12 +346,16 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
         workchain = self.ctx.workchain_ph
 
         if not workchain.is_finished_ok:
-            self.report(f'PhBaseWorkChain<{workchain.pk}> failed with exit status {workchain.exit_status}')
+            self.report(
+                f"PhBaseWorkChain<{workchain.pk}> failed with exit status {workchain.exit_status}"
+            )
             return self.exit_codes.ERROR_SUB_PROCESS_FAILED_PHONON
 
     def run_epw(self):
-        """Run the `EpwBaseWorkChain`."""        
-        inputs = AttributeDict(self.exposed_inputs(EpwBaseWorkChain), namespace='epw_base')
+        """Run the `EpwBaseWorkChain`."""
+        inputs = AttributeDict(
+            self.exposed_inputs(EpwBaseWorkChain), namespace="epw_base"
+        )
 
         # The EpwBaseWorkChain will take the parent folder of the previous
         # PhCalculation, PwCalculation, and Wannier90Calculation.
@@ -290,8 +363,13 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
 
         w90_workchain = self.ctx.workchain_w90_bands
         inputs.parent_folder_nscf = w90_workchain.outputs.nscf.remote_folder
-        if self.ctx.w90_class_name == 'Wannier90OptimizeWorkChain' and w90_workchain.inputs.optimize_disproj:
-            inputs.parent_folder_chk = w90_workchain.outputs.wannier90_optimal__remote_folder
+        if (
+            self.ctx.w90_class_name == "Wannier90OptimizeWorkChain"
+            and w90_workchain.inputs.optimize_disproj
+        ):
+            inputs.parent_folder_chk = (
+                w90_workchain.outputs.wannier90_optimal__remote_folder
+            )
         else:
             inputs.parent_folder_chk = w90_workchain.outputs.wannier90.remote_folder
 
@@ -304,12 +382,14 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
         inputs.kpoints = self.ctx.kpoints_nscf
         inputs.kfpoints = fine_points
         inputs.qpoints = self.ctx.qpoints
-        inputs.qfpoints = fine_points      
+        inputs.qfpoints = fine_points
 
-        inputs.metadata.call_link_label = 'epw_base'
+        inputs.metadata.call_link_label = "epw_base"
 
         workchain_node = self.submit(EpwBaseWorkChain, **inputs)
-        self.report(f'launching EpwBaseWorkChain<{workchain_node.pk}> in transformation mode')
+        self.report(
+            f"launching EpwBaseWorkChain<{workchain_node.pk}> in transformation mode"
+        )
 
         return ToContext(workchain_epw=workchain_node)
 
@@ -318,20 +398,22 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
         workchain = self.ctx.workchain_epw
 
         if not workchain.is_finished_ok:
-            self.report(f'EpwBaseWorkChain<{workchain.pk}> failed with exit status {workchain.exit_status}')
+            self.report(
+                f"EpwBaseWorkChain<{workchain.pk}> failed with exit status {workchain.exit_status}"
+            )
             return self.exit_codes.ERROR_SUB_PROCESS_FAILED_EPW
 
     def results(self):
         """Add the most important results to the outputs of the work chain."""
-        self.out('retrieved', self.ctx.workchain_epw.outputs.retrieved)
-        self.out('epw_folder', self.ctx.workchain_epw.outputs.remote_stash)
+        self.out("retrieved", self.ctx.workchain_epw.outputs.retrieved)
+        self.out("epw_folder", self.ctx.workchain_epw.outputs.remote_stash)
 
     def on_terminated(self):
         """Clean the working directories of all child calculations if `clean_workdir=True` in the inputs."""
         super().on_terminated()
 
         if self.inputs.clean_workdir.value is False:
-            self.report('remote folders will not be cleaned')
+            self.report("remote folders will not be cleaned")
             return
 
         cleaned_calcs = []
@@ -345,4 +427,6 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
                     pass
 
         if cleaned_calcs:
-            self.report(f"cleaned remote folders of calculations: {' '.join(map(str, cleaned_calcs))}")
+            self.report(
+                f"cleaned remote folders of calculations: {' '.join(map(str, cleaned_calcs))}"
+            )

--- a/src/aiida_epw/workflows/supercon.py
+++ b/src/aiida_epw/workflows/supercon.py
@@ -1,4 +1,7 @@
 """Work chain for computing the critical temperature based on an `EpwWorkChain`."""
+
+from scipy.interpolate import interp1d
+
 from aiida import orm
 from aiida.common import AttributeDict
 from aiida.engine import WorkChain, ToContext, while_, if_, append_
@@ -6,7 +9,6 @@ from aiida.engine import WorkChain, ToContext, while_, if_, append_
 from aiida_quantumespresso.workflows.protocols.utils import ProtocolMixin
 
 from aiida_epw.workflows.base import EpwBaseWorkChain
-from aiida_quantumespresso.calculations.functions.create_kpoints_from_distance import create_kpoints_from_distance
 
 from aiida.engine import calcfunction
 
@@ -29,14 +31,12 @@ def stash_to_remote(stash_data: orm.RemoteStashFolderData) -> orm.RemoteData:
 
 @calcfunction
 def split_list(list_node: orm.List) -> dict:
-    return {f'el_{no}': orm.Float(el) for no, el in enumerate(list_node.get_list())}
-
-from scipy.interpolate import interp1d
+    return {f"el_{no}": orm.Float(el) for no, el in enumerate(list_node.get_list())}
 
 
 @calcfunction
 def calculate_tc(max_eigenvalue: orm.XyData) -> orm.Float:
-    me_array = max_eigenvalue.get_array('max_eigenvalue')
+    me_array = max_eigenvalue.get_array("max_eigenvalue")
     try:
         return orm.Float(float(interp1d(me_array[:, 1], me_array[:, 0])(1.0)))
     except ValueError:
@@ -44,9 +44,9 @@ def calculate_tc(max_eigenvalue: orm.XyData) -> orm.Float:
 
 
 class SuperConWorkChain(ProtocolMixin, WorkChain):
-    """This workchain will run a series of `EpwBaseWorkChain`s in interpolation mode to converge 
-    the Allen-Dynes Tc according to the interpolation distance, if converged or forced by `always_run_final`, 
-    it will then run the final isotropic and anisotropic `EpwBaseWorkChain`s to compute the 
+    """This workchain will run a series of `EpwBaseWorkChain`s in interpolation mode to converge
+    the Allen-Dynes Tc according to the interpolation distance, if converged or forced by `always_run_final`,
+    it will then run the final isotropic and anisotropic `EpwBaseWorkChain`s to compute the
     critical temperature solving the isotropic and anisotropic Migdal-Eliashberg equations."""
 
     @classmethod
@@ -54,36 +54,63 @@ class SuperConWorkChain(ProtocolMixin, WorkChain):
         """Define the work chain specification."""
         super().define(spec)
 
-        spec.input('structure', valid_type=orm.StructureData)
-        spec.input('clean_workdir', valid_type=orm.Bool, default=lambda: orm.Bool(False))
-        spec.input('parent_folder_epw', valid_type=(orm.RemoteData, orm.RemoteStashFolderData))
-        spec.input('interpolation_distance', valid_type=(orm.Float, orm.List))
-        spec.input('convergence_threshold', valid_type=orm.Float, required=False)
-        spec.input('always_run_final', valid_type=orm.Bool, default=lambda: orm.Bool(False))
+        spec.input("structure", valid_type=orm.StructureData)
+        spec.input(
+            "clean_workdir", valid_type=orm.Bool, default=lambda: orm.Bool(False)
+        )
+        spec.input(
+            "parent_folder_epw", valid_type=(orm.RemoteData, orm.RemoteStashFolderData)
+        )
+        spec.input("interpolation_distance", valid_type=(orm.Float, orm.List))
+        spec.input("convergence_threshold", valid_type=orm.Float, required=False)
+        spec.input(
+            "always_run_final", valid_type=orm.Bool, default=lambda: orm.Bool(False)
+        )
 
         spec.expose_inputs(
-            EpwBaseWorkChain, namespace='epw_interp', exclude=(
-                'clean_workdir', 'parent_folder_ph', 'parent_folder_nscf', 'parent_folder_chk', 'qfpoints', 'kfpoints'
+            EpwBaseWorkChain,
+            namespace="epw_interp",
+            exclude=(
+                "clean_workdir",
+                "parent_folder_ph",
+                "parent_folder_nscf",
+                "parent_folder_chk",
+                "qfpoints",
+                "kfpoints",
             ),
             namespace_options={
-                'help': 'Inputs for the interpolation `EpwBaseWorkChain`s.'
-            }
+                "help": "Inputs for the interpolation `EpwBaseWorkChain`s."
+            },
         )
         spec.expose_inputs(
-            EpwBaseWorkChain, namespace='epw_final_iso', exclude=(
-                'clean_workdir', 'parent_folder_ph', 'parent_folder_nscf', 'parent_folder_chk', 'qfpoints_distance', 'kfpoints_factor'
+            EpwBaseWorkChain,
+            namespace="epw_final_iso",
+            exclude=(
+                "clean_workdir",
+                "parent_folder_ph",
+                "parent_folder_nscf",
+                "parent_folder_chk",
+                "qfpoints_distance",
+                "kfpoints_factor",
             ),
             namespace_options={
-                'help': 'Inputs for the final isotropic `EpwBaseWorkChain`.'
-            }
+                "help": "Inputs for the final isotropic `EpwBaseWorkChain`."
+            },
         )
         spec.expose_inputs(
-            EpwBaseWorkChain, namespace='epw_final_aniso', exclude=(
-                'clean_workdir', 'parent_folder_ph', 'parent_folder_nscf', 'parent_folder_chk', 'qfpoints_distance', 'kfpoints_factor'
+            EpwBaseWorkChain,
+            namespace="epw_final_aniso",
+            exclude=(
+                "clean_workdir",
+                "parent_folder_ph",
+                "parent_folder_nscf",
+                "parent_folder_chk",
+                "qfpoints_distance",
+                "kfpoints_factor",
             ),
             namespace_options={
-                'help': 'Inputs for the final anisotropic `EpwBaseWorkChain`.'
-            }
+                "help": "Inputs for the final anisotropic `EpwBaseWorkChain`."
+            },
         )
         spec.outline(
             cls.setup,
@@ -97,45 +124,65 @@ class SuperConWorkChain(ProtocolMixin, WorkChain):
                 cls.run_final_epw_aniso,
                 cls.inspect_final_epw_aniso,
             ),
-
-            cls.results
+            cls.results,
         )
-        spec.output('parameters', valid_type=orm.Dict,
-                    help='The `output_parameters` output node of the final EPW calculation.')
-        spec.output('max_eigenvalue', valid_type=orm.XyData,
-                    help='The temperature dependence of the max eigenvalue for the final EPW.')
-        spec.output('a2f', valid_type=orm.XyData,
-                    help='The contents of the `.a2f` file for the final EPW.')
-        spec.output('Tc_iso', valid_type=orm.Float,
-                    help='The critical temperature.')
+        spec.output(
+            "parameters",
+            valid_type=orm.Dict,
+            help="The `output_parameters` output node of the final EPW calculation.",
+        )
+        spec.output(
+            "max_eigenvalue",
+            valid_type=orm.XyData,
+            help="The temperature dependence of the max eigenvalue for the final EPW.",
+        )
+        spec.output(
+            "a2f",
+            valid_type=orm.XyData,
+            help="The contents of the `.a2f` file for the final EPW.",
+        )
+        spec.output("Tc_iso", valid_type=orm.Float, help="The critical temperature.")
 
-        spec.exit_code(401, 'ERROR_SUB_PROCESS_EPW_INTERP',
-            message='The interpolation `EpwBaseWorkChain` sub process failed')
-        spec.exit_code(402, 'ERROR_ALLEN_DYNES_NOT_CONVERGED',
-            message='Allen-Dynes Tc is not converged.')
-        spec.exit_code(403, 'ERROR_SUB_PROCESS_EPW_ISO',
-            message='The isotropic `EpwBaseWorkChain` sub process failed')
-        spec.exit_code(404, 'ERROR_SUB_PROCESS_EPW_ANISO',
-            message='The anisotropic `EpwBaseWorkChain` sub process failed')
+        spec.exit_code(
+            401,
+            "ERROR_SUB_PROCESS_EPW_INTERP",
+            message="The interpolation `EpwBaseWorkChain` sub process failed",
+        )
+        spec.exit_code(
+            402,
+            "ERROR_ALLEN_DYNES_NOT_CONVERGED",
+            message="Allen-Dynes Tc is not converged.",
+        )
+        spec.exit_code(
+            403,
+            "ERROR_SUB_PROCESS_EPW_ISO",
+            message="The isotropic `EpwBaseWorkChain` sub process failed",
+        )
+        spec.exit_code(
+            404,
+            "ERROR_SUB_PROCESS_EPW_ANISO",
+            message="The anisotropic `EpwBaseWorkChain` sub process failed",
+        )
 
     @classmethod
     def get_protocol_filepath(cls):
         """Return ``pathlib.Path`` to the ``.yaml`` file that defines the protocols."""
         from importlib_resources import files
         from . import protocols
-        return files(protocols) / 'supercon.yaml'
+
+        return files(protocols) / "supercon.yaml"
 
     @classmethod
     def get_builder_from_protocol(
-            cls, 
-            epw_code, 
-            parent_epw, 
-            protocol=None, 
-            overrides=None, 
-            scon_epw_code=None, 
-            parent_folder_epw=None, 
-            **kwargs
-        ):
+        cls,
+        epw_code,
+        parent_epw,
+        protocol=None,
+        overrides=None,
+        scon_epw_code=None,
+        parent_folder_epw=None,
+        **kwargs,
+    ):
         """Return a builder prepopulated with inputs selected according to the chosen protocol.
 
         :TODO:
@@ -144,36 +191,41 @@ class SuperConWorkChain(ProtocolMixin, WorkChain):
 
         builder = cls.get_builder()
 
-        if parent_epw.process_label == 'EpwPrepWorkChain':
-            epw_source = parent_epw.base.links.get_outgoing(link_label_filter='epw_base').first().node
-        elif parent_epw.process_label == 'EpwBaseWorkChain':
+        if parent_epw.process_label == "EpwPrepWorkChain":
+            epw_source = (
+                parent_epw.base.links.get_outgoing(link_label_filter="epw_base")
+                .first()
+                .node
+            )
+        elif parent_epw.process_label == "EpwBaseWorkChain":
             epw_source = parent_epw
         else:
-            raise ValueError(f'Invalid parent_epw process: {parent_epw.process_label}')
+            raise ValueError(f"Invalid parent_epw process: {parent_epw.process_label}")
 
         if parent_folder_epw is None:
-
-            if epw_source.inputs.epw.code.computer.hostname != epw_code.computer.hostname:
+            if (
+                epw_source.inputs.epw.code.computer.hostname
+                != epw_code.computer.hostname
+            ):
                 raise ValueError(
-                    'The `epw_code` must be configured on the same computer as that where the `parent_epw` was run.'
+                    "The `epw_code` must be configured on the same computer as that where the `parent_epw` was run."
                 )
             parent_folder_epw = parent_epw.outputs.epw_folder
         else:
             # TODO: Add check to make sure parent_folder_epw is on same computer as epw_code
             pass
 
-        for epw_namespace in ('epw_interp', 'epw_final_iso', 'epw_final_aniso'):
-
+        for epw_namespace in ("epw_interp", "epw_final_iso", "epw_final_aniso"):
             epw_inputs = inputs.get(epw_namespace, None)
 
             epw_builder = EpwBaseWorkChain.get_builder_from_protocol(
                 code=epw_code,
                 structure=epw_source.inputs.structure,
                 protocol=protocol,
-                overrides=epw_inputs
+                overrides=epw_inputs,
             )
 
-            if epw_namespace == 'epw_interp' and scon_epw_code is not None:
+            if epw_namespace == "epw_interp" and scon_epw_code is not None:
                 epw_builder.code = scon_epw_code
             else:
                 epw_builder.code = epw_code
@@ -181,27 +233,27 @@ class SuperConWorkChain(ProtocolMixin, WorkChain):
             epw_builder.kpoints = epw_source.inputs.kpoints
             epw_builder.qpoints = epw_source.inputs.qpoints
 
-            if 'settings' in epw_inputs:
-                epw_builder.settings = orm.Dict(epw_inputs['settings'])
+            if "settings" in epw_inputs:
+                epw_builder.settings = orm.Dict(epw_inputs["settings"])
 
-            builder[epw_namespace]= epw_builder
+            builder[epw_namespace] = epw_builder
 
-        if isinstance(inputs['interpolation_distance'], float):
-            builder.interpolation_distance = orm.Float(inputs['interpolation_distance'])
-        if isinstance(inputs['interpolation_distance'], list):
-            builder.interpolation_distance = orm.List(inputs['interpolation_distance'])
+        if isinstance(inputs["interpolation_distance"], float):
+            builder.interpolation_distance = orm.Float(inputs["interpolation_distance"])
+        if isinstance(inputs["interpolation_distance"], list):
+            builder.interpolation_distance = orm.List(inputs["interpolation_distance"])
 
-        builder.convergence_threshold = orm.Float(inputs['convergence_threshold'])
-        builder.always_run_final = orm.Bool(inputs.get('always_run_final', False))
+        builder.convergence_threshold = orm.Float(inputs["convergence_threshold"])
+        builder.always_run_final = orm.Bool(inputs.get("always_run_final", False))
         builder.structure = parent_epw.inputs.structure
         builder.parent_folder_epw = parent_folder_epw
-        builder.clean_workdir = orm.Bool(inputs['clean_workdir'])
+        builder.clean_workdir = orm.Bool(inputs["clean_workdir"])
 
         return builder
 
     def setup(self):
         """Setup steps, i.e. initialise context variables."""
-        intp = self.inputs.get('interpolation_distance')
+        intp = self.inputs.get("interpolation_distance")
         if isinstance(intp, orm.List):
             self.ctx.interpolation_list = list(split_list(intp).values())
         else:
@@ -216,40 +268,52 @@ class SuperConWorkChain(ProtocolMixin, WorkChain):
 
     def should_run_conv(self):
         """Check if the convergence loop should continue or not."""
-        if 'convergence_threshold' in self.inputs:
+        if "convergence_threshold" in self.inputs:
             try:
-                self.ctx.epw_interp[-3].outputs.output_parameters['allen_dynes']  # This is to check that we have at least 3 allen-dynes
-                prev_allen_dynes = self.ctx.epw_interp[-2].outputs.output_parameters['allen_dynes']
-                new_allen_dynes = self.ctx.epw_interp[-1].outputs.output_parameters['allen_dynes']
+                self.ctx.epw_interp[-3].outputs.output_parameters[
+                    "allen_dynes"
+                ]  # This is to check that we have at least 3 allen-dynes
+                prev_allen_dynes = self.ctx.epw_interp[-2].outputs.output_parameters[
+                    "allen_dynes"
+                ]
+                new_allen_dynes = self.ctx.epw_interp[-1].outputs.output_parameters[
+                    "allen_dynes"
+                ]
                 self.ctx.is_converged = (
                     abs(prev_allen_dynes - new_allen_dynes)
                     < self.inputs.convergence_threshold
                 )
-                self.report(f'Checking convergence: old {prev_allen_dynes}; new {new_allen_dynes} -> Converged = {self.ctx.is_converged.value}')
-            except (AttributeError, IndexError, KeyError):
-                self.report('Not enough data to check convergence.')
-            # 
-            if (
-                len(self.ctx.interpolation_list) == 0 and 
-                not self.ctx.is_converged and 
-                self.inputs.always_run_final.value
-                ):
                 self.report(
-                    'Allen-Dynes Tc is not converged, '
-                    'but will run the subsequent isotropic and anisotropic workchains as required.'
-                    )
+                    f"Checking convergence: old {prev_allen_dynes}; new {new_allen_dynes} -> Converged = {self.ctx.is_converged.value}"
+                )
+            except (AttributeError, IndexError, KeyError):
+                self.report("Not enough data to check convergence.")
+            #
+            if (
+                len(self.ctx.interpolation_list) == 0
+                and not self.ctx.is_converged
+                and self.inputs.always_run_final.value
+            ):
+                self.report(
+                    "Allen-Dynes Tc is not converged, "
+                    "but will run the subsequent isotropic and anisotropic workchains as required."
+                )
         else:
-            self.report('No `convergence_threshold` input was provided, convergence automatically achieved.')
+            self.report(
+                "No `convergence_threshold` input was provided, convergence automatically achieved."
+            )
             self.ctx.is_converged = True
 
         return len(self.ctx.interpolation_list) > 0 and not self.ctx.is_converged
 
     def run_conv(self):
         """Run the EpwBaseWorkChain in interpolation mode for the current interpolation distance."""
-        
+
         self.ctx.iteration += 1
 
-        inputs = AttributeDict(self.exposed_inputs(EpwBaseWorkChain, namespace='epw_interp'))
+        inputs = AttributeDict(
+            self.exposed_inputs(EpwBaseWorkChain, namespace="epw_interp")
+        )
 
         inputs.parent_folder_epw = self.inputs.parent_folder_epw
         inputs.kfpoints_factor = self.inputs.epw_interp.kfpoints_factor
@@ -257,13 +321,17 @@ class SuperConWorkChain(ProtocolMixin, WorkChain):
 
         if self.ctx.degaussq:
             parameters = inputs.parameters.get_dict()
-            parameters['INPUTEPW']['degaussq'] = self.ctx.degaussq
+            parameters["INPUTEPW"]["degaussq"] = self.ctx.degaussq
             inputs.parameters = orm.Dict(parameters)
 
-        inputs.setdefault('metadata', {})['call_link_label'] = f'conv_{self.ctx.iteration:02d}'
-        workchain_node  = self.submit(EpwBaseWorkChain, **inputs)
+        inputs.setdefault("metadata", {})["call_link_label"] = (
+            f"conv_{self.ctx.iteration:02d}"
+        )
+        workchain_node = self.submit(EpwBaseWorkChain, **inputs)
 
-        self.report(f'launching EpwBaseWorkChain<{workchain_node.pk}> in a2f mode: convergence #{self.ctx.iteration}')
+        self.report(
+            f"launching EpwBaseWorkChain<{workchain_node.pk}> in a2f mode: convergence #{self.ctx.iteration}"
+        )
 
         return ToContext(epw_interp=append_(workchain_node))
 
@@ -272,16 +340,22 @@ class SuperConWorkChain(ProtocolMixin, WorkChain):
         workchain = self.ctx.epw_interp[-1]
 
         if not workchain.is_finished_ok:
-            self.report(f'EpwBaseWorkChain<{workchain.pk}> failed with exit status {workchain.exit_status}')
+            self.report(
+                f"EpwBaseWorkChain<{workchain.pk}> failed with exit status {workchain.exit_status}"
+            )
             self.ctx.epw_interp.pop()
         else:
             try:
-                self.report(f"Allen-Dynes: {workchain.outputs.output_parameters['Allen_Dynes_Tc']}")
+                self.report(
+                    f"Allen-Dynes: {workchain.outputs.output_parameters['Allen_Dynes_Tc']}"
+                )
             except KeyError:
-                self.report(f"Could not find Allen-Dynes temperature in parsed output parameters!")
+                self.report(
+                    "Could not find Allen-Dynes temperature in parsed output parameters!"
+                )
 
             if self.ctx.degaussq is None:
-                frequency = workchain.outputs.a2f.get_array('frequency')
+                frequency = workchain.outputs.a2f.get_array("frequency")
                 self.ctx.degaussq = frequency[-1] / 100
 
     def should_run_final(self):
@@ -289,12 +363,14 @@ class SuperConWorkChain(ProtocolMixin, WorkChain):
         if self.ctx.is_converged or self.inputs.always_run_final.value:
             return True
         else:
-            self.report(f'Allen-Dynes Tc is not converged.')
+            self.report("Allen-Dynes Tc is not converged.")
             return self.exit_codes.ERROR_ALLEN_DYNES_NOT_CONVERGED
 
     def run_final_epw_iso(self):
         """Run the final EpwBaseWorkChain in isotropic mode."""
-        inputs = AttributeDict(self.exposed_inputs(EpwBaseWorkChain, namespace='epw_final_iso'))
+        inputs = AttributeDict(
+            self.exposed_inputs(EpwBaseWorkChain, namespace="epw_final_iso")
+        )
 
         parent_folder_epw = self.ctx.epw_interp[-1].outputs.remote_folder
         inputs.parent_folder_epw = parent_folder_epw
@@ -303,13 +379,15 @@ class SuperConWorkChain(ProtocolMixin, WorkChain):
 
         if self.ctx.degaussq:
             parameters = inputs.parameters.get_dict()
-            parameters['INPUTEPW']['degaussq'] = self.ctx.degaussq
+            parameters["INPUTEPW"]["degaussq"] = self.ctx.degaussq
             inputs.parameters = orm.Dict(parameters)
 
-        inputs.metadata.call_link_label = 'epw_final_iso'
+        inputs.metadata.call_link_label = "epw_final_iso"
 
         workchain_node = self.submit(EpwBaseWorkChain, **inputs)
-        self.report(f'launching EpwBaseWorkChain<{workchain_node.pk}> in isotropic mode')
+        self.report(
+            f"launching EpwBaseWorkChain<{workchain_node.pk}> in isotropic mode"
+        )
 
         return ToContext(final_epw_iso=workchain_node)
 
@@ -318,45 +396,53 @@ class SuperConWorkChain(ProtocolMixin, WorkChain):
         workchain = self.ctx.final_epw_iso
 
         if not workchain.is_finished_ok:
-            self.report(f'EpwBaseWorkChain<{workchain.pk}> failed with exit status {workchain.exit_status}')
+            self.report(
+                f"EpwBaseWorkChain<{workchain.pk}> failed with exit status {workchain.exit_status}"
+            )
             return self.exit_codes.ERROR_SUB_PROCESS_EPW_ISO
 
     def run_final_epw_aniso(self):
         """Run the EpwBaseWorkChain in anisotropic mode for the current interpolation distance."""
-        inputs = AttributeDict(self.exposed_inputs(EpwBaseWorkChain, namespace='epw_final_aniso'))
+        inputs = AttributeDict(
+            self.exposed_inputs(EpwBaseWorkChain, namespace="epw_final_aniso")
+        )
 
         parent_folder_epw = self.ctx.epw_interp[-1].outputs.remote_folder
         inputs.parent_folder_epw = parent_folder_epw
         inputs.kfpoints = parent_folder_epw.creator.inputs.kfpoints
         inputs.qfpoints = parent_folder_epw.creator.inputs.qfpoints
 
-        inputs.metadata.call_link_label = 'epw_final_aniso'
+        inputs.metadata.call_link_label = "epw_final_aniso"
         workchain_node = self.submit(EpwBaseWorkChain, **inputs)
-        self.report(f'launching EpwBaseWorkChain<{workchain_node.pk}> in anisotropic mode')
+        self.report(
+            f"launching EpwBaseWorkChain<{workchain_node.pk}> in anisotropic mode"
+        )
 
-        return ToContext(final_epw_aniso=workchain_node)    
+        return ToContext(final_epw_aniso=workchain_node)
 
     def inspect_final_epw_aniso(self):
         """Verify that the final EpwBaseWorkChain in anisotropic mode finished successfully."""
         workchain = self.ctx.final_epw_aniso
 
         if not workchain.is_finished_ok:
-            self.report(f'EpwBaseWorkChain<{workchain.pk}> failed with exit status {workchain.exit_status}')
+            self.report(
+                f"EpwBaseWorkChain<{workchain.pk}> failed with exit status {workchain.exit_status}"
+            )
             return self.exit_codes.ERROR_SUB_PROCESS_EPW_ANISO
 
     def results(self):
         """TODO"""
-        self.out('Tc_iso', calculate_tc(self.ctx.final_epw_iso.outputs.max_eigenvalue))
-        self.out('parameters', self.ctx.final_epw_iso.outputs.output_parameters)
-        self.out('max_eigenvalue', self.ctx.final_epw_iso.outputs.max_eigenvalue)
-        self.out('a2f', self.ctx.final_epw_iso.outputs.a2f)
+        self.out("Tc_iso", calculate_tc(self.ctx.final_epw_iso.outputs.max_eigenvalue))
+        self.out("parameters", self.ctx.final_epw_iso.outputs.output_parameters)
+        self.out("max_eigenvalue", self.ctx.final_epw_iso.outputs.max_eigenvalue)
+        self.out("a2f", self.ctx.final_epw_iso.outputs.a2f)
 
     def on_terminated(self):
         """Clean the working directories of all child calculations if `clean_workdir=True` in the inputs."""
         super().on_terminated()
 
         if self.inputs.clean_workdir.value is False:
-            self.report('remote folders will not be cleaned')
+            self.report("remote folders will not be cleaned")
             return
 
         cleaned_calcs = []
@@ -370,5 +456,6 @@ class SuperConWorkChain(ProtocolMixin, WorkChain):
                     pass
 
         if cleaned_calcs:
-            self.report(f"cleaned remote folders of calculations: {' '.join(map(str, cleaned_calcs))}")
-
+            self.report(
+                f"cleaned remote folders of calculations: {' '.join(map(str, cleaned_calcs))}"
+            )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Project-wide pytest fixtures & hooks.
+
+Docs: https://docs.pytest.org/en/stable/how-to/fixtures.html#conftest-py-sharing-fixtures-across-multiple-files
+"""
+
+import pytest
+
+
+@pytest.fixture
+def readability_counts() -> bool:
+    return True

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,0 +1,2 @@
+def test_example(readability_counts):
+    assert readability_counts is True


### PR DESCRIPTION
Adapt the `pyproject.toml` to allow more options for development besides Hatch:

1. add extras for the various developer operations: `pre-commit`, `tests` and `docs`.
2. add the `dev` dependency group, which `uv` uses by default in its environments.

To support these options, adapt the pre-commit configuration to run the Ruff hook directly from their repository.

Improve the Hatch environments, most importantly adapt the `test` environment so we can run `hatch test` for different Python versions or all supported ones.

See the release for more details:

https://github.com/mbercx/python-copier/releases/tag/v0.11.1