### PR TITLE
🐛 `workflow`: Fix bugs in EpwPrepWorkChain

### DIFF
--- a/src/aiida_epw/workflows/prep.py
+++ b/src/aiida_epw/workflows/prep.py
@@ -188,22 +188,22 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
         spec.exit_code(
             403,
             "ERROR_SUB_PROCESS_FAILED_PHONON",
-            message="The electron-phonon `PhBaseWorkChain` sub process failed",
+            message="The `PhBaseWorkChain` subprocess failed",
         )
         spec.exit_code(
             404,
             "ERROR_SUB_PROCESS_FAILED_WANNIER90",
-            message="The `Wannier90BandsWorkChain` sub process failed",
+            message="The `Wannier90BandsWorkChain/Wannier90OptimizeWorkChain` subprocess failed",
         )
         spec.exit_code(
             405,
             "ERROR_SUB_PROCESS_FAILED_EPW",
-            message="The `EpwWorkChain` sub process failed",
+            message="The `EpwBaseWorkChain` subprocess failed",
         )
         spec.exit_code(
             406,
             "ERROR_SUB_PROCESS_FAILED_EPW_BANDS",
-            message="The `EpwBaseWorkChain` sub process failed",
+            message="The `EpwBaseWorkChain` for bands interpolation subprocess failed",
         )
 
     @classmethod
@@ -243,16 +243,13 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
         w90_bands_inputs = inputs.get("w90_bands", {})
         pseudo_family = inputs.pop("pseudo_family", None)
 
-        if wannier_projection_type == WannierProjectionType.ATOMIC_PROJECTORS_QE:
-            if reference_bands is None:
-                raise ValueError(
-                    f"reference_bands must be specified for {wannier_projection_type}"
-                )
+        if reference_bands:
             w90_bands = Wannier90OptimizeWorkChain.get_builder_from_protocol(
                 structure=structure,
                 codes=codes,
                 pseudo_family=pseudo_family,
                 overrides=w90_bands_inputs,
+                projection_type=wannier_projection_type,
                 reference_bands=reference_bands,
                 bands_kpoints=bands_kpoints,
             )
@@ -260,17 +257,17 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
             # pop useless inputs, otherwise the builder validation will fail
             # at validating empty inputs
             w90_bands.pop("projwfc", None)
-        elif wannier_projection_type == WannierProjectionType.SCDM:
+        else:
             w90_bands = Wannier90BandsWorkChain.get_builder_from_protocol(
                 structure=structure,
                 codes=codes,
                 pseudo_family=pseudo_family,
                 overrides=w90_bands_inputs,
+                projection_type=wannier_projection_type,
+                bands_kpoints=bands_kpoints,
             )
-        else:
-            raise ValueError(
-                f"Unsupported wannier_projection_type: {wannier_projection_type}"
-            )
+        if wannier_projection_type == WannierProjectionType.ATOMIC_PROJECTORS_QE:
+            w90_bands.pop("projwfc", None)
 
         w90_bands.pop("structure", None)
         w90_bands.pop("open_grid", None)
@@ -359,17 +356,20 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
 
     def run_wannier90(self):
         """Run the wannier90 workflow."""
-        if "projwfc" in self.inputs.w90_bands:
-            w90_class = Wannier90BandsWorkChain
-        else:
+        inputs = AttributeDict(
+            self.exposed_inputs(
+                Wannier90OptimizeWorkChain, namespace="w90_bands"
+            )
+        )
+        if "reference_bands" in self.inputs.w90_bands:
             w90_class = Wannier90OptimizeWorkChain
+            # inputs.pop('projwfc')
+        else:
+            w90_class = Wannier90BandsWorkChain
 
         self.ctx.w90_class_name = w90_class.get_name()
         self.report(f"Running a {self.ctx.w90_class_name}.")
 
-        inputs = AttributeDict(
-            self.exposed_inputs(Wannier90OptimizeWorkChain, namespace="w90_bands")
-        )
         inputs.metadata.call_link_label = "w90_bands"
         inputs.structure = self.inputs.structure
 
@@ -427,9 +427,10 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
     def run_epw(self):
         """Run the `EpwBaseWorkChain`."""
         inputs = AttributeDict(
-            self.exposed_inputs(EpwBaseWorkChain), namespace="epw_base"
+            self.exposed_inputs(EpwBaseWorkChain, namespace="epw_base")
         )
 
+        inputs.structure = self.inputs.structure
         # The EpwBaseWorkChain will take the parent folder of the previous
         # PhCalculation, PwCalculation, and Wannier90Calculation.
         inputs.parent_folder_ph = self.ctx.workchain_ph.outputs.remote_folder
@@ -477,7 +478,7 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
             return self.exit_codes.ERROR_SUB_PROCESS_FAILED_EPW
 
     def should_run_epw_bands(self):
-        """Check if the `EpwBaseWorkChain` should be run in bands mode."""
+        """Check if the bands interpolation should be run."""
         return "epw_bands" in self.inputs
 
     def run_epw_bands(self):

--- a/src/aiida_epw/workflows/prep.py
+++ b/src/aiida_epw/workflows/prep.py
@@ -357,9 +357,7 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
     def run_wannier90(self):
         """Run the wannier90 workflow."""
         inputs = AttributeDict(
-            self.exposed_inputs(
-                Wannier90OptimizeWorkChain, namespace="w90_bands"
-            )
+            self.exposed_inputs(Wannier90OptimizeWorkChain, namespace="w90_bands")
         )
         if "reference_bands" in self.inputs.w90_bands:
             w90_class = Wannier90OptimizeWorkChain

--- a/src/aiida_epw/workflows/protocols/prep.yaml
+++ b/src/aiida_epw/workflows/protocols/prep.yaml
@@ -41,6 +41,8 @@ default_inputs:
           - aiida.kgmap
           - aiida.kmap
           - aiida.ukk
+          - aiida.mmn
+          - aiida.bvec
           - out/aiida.epmatwp
           - save
     parameters:


### PR DESCRIPTION
- Fix typo and ambiguity in help strings.
- Decide to use either Wannier90OptimizeWorkChain or Wannier90BandsWorkChain upon the existence of reference_bands input.
- Fix the bug that namespace="epw_base" is out of the scope of function exposed_inputs in run_epw
- Add aiida.mmn and aiida.bvec in stash list since they are used in EPW v6.0