### PR TITLE
✨ data: Add custom EPW datatypes and corresponding unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,13 @@ Source = "https://github.com/aiidaplugins/aiida-epw"
 [project.entry-points.'aiida.parsers']
 'epw.epw' = 'aiida_epw.parsers.epw:EpwParser'
 
+[project.entry-points.'aiida.data']
+'epw.a2f' = 'aiida_epw.data.a2f:A2fData'
+'epw.gap_function' = 'aiida_epw.data.gap_function:GapFunctionData'
+'epw.lambda_fs' = 'aiida_epw.data.lambda_fs:LambdaFSData'
+'epw.lambda_k_pairs' = 'aiida_epw.data.lambda_k_pairs:LambdaKPairsData'
+'epw.projected_spectrum' = 'aiida_epw.data.projected_spectrum:ProjectedSpectrumData'
+
 [project.entry-points.'aiida.workflows']
 'epw.base' = 'aiida_epw.workflows.base:EpwBaseWorkChain'
 'epw.epw_prep' = 'aiida_epw.workflows.prep:EpwPrepWorkChain'

--- a/src/aiida_epw/data/__init__.py
+++ b/src/aiida_epw/data/__init__.py
@@ -1,0 +1,15 @@
+"""Custom AiiDA data types for aiida-epw."""
+
+from .a2f import A2fData
+from .gap_function import GapFunctionData
+from .lambda_fs import LambdaFSData
+from .lambda_k_pairs import LambdaKPairsData
+from .projected_spectrum import ProjectedSpectrumData
+
+__all__ = (
+    "A2fData",
+    "GapFunctionData",
+    "LambdaFSData",
+    "LambdaKPairsData",
+    "ProjectedSpectrumData",
+)

--- a/src/aiida_epw/data/a2f.py
+++ b/src/aiida_epw/data/a2f.py
@@ -1,0 +1,163 @@
+"""Domain-specific data type for EPW ``.a2f`` spectra."""
+
+import numpy
+from aiida import orm
+from aiida.common import exceptions
+
+
+class A2fData(orm.ArrayData):
+    """Store an EPW a2F spectrum together with its smearing grids and metadata."""
+
+    ARRAY_FREQUENCY = "frequency"
+    ARRAY_RAW_SPECTRUM = "a2f"
+    ARRAY_SPECTRUM = "a2f_spectrum"
+    ARRAY_CUMULATIVE_LAMBDA = "lambda_cumulative"
+    ARRAY_LAMBDA = "lambda"
+    ARRAY_PHONON_SMEARING = "degaussq"
+
+    ATTRIBUTE_ELECTRON_SMEARING = "electron_smearing"
+    ATTRIBUTE_FERMI_WINDOW = "fermi_window"
+    ATTRIBUTE_SUMMED_ELPH_COUPLING = "summed_elph_coupling"
+
+    def set_a2f_data(
+        self,
+        frequency,
+        spectrum,
+        lambda_values,
+        phonon_smearing,
+        *,
+        cumulative_lambda=None,
+        electron_smearing=None,
+        fermi_window=None,
+        summed_elph_coupling=None,
+    ):
+        """Store the EPW a2F spectrum and validate the expected array shapes."""
+        frequency = numpy.array(frequency, dtype=float)
+        spectrum = numpy.array(spectrum, dtype=float)
+        lambda_values = numpy.array(lambda_values, dtype=float)
+        phonon_smearing = numpy.array(phonon_smearing, dtype=float)
+        if cumulative_lambda is not None:
+            cumulative_lambda = numpy.array(cumulative_lambda, dtype=float)
+
+        if frequency.ndim != 1:
+            raise exceptions.ValidationError(
+                "`frequency` must be a one-dimensional array."
+            )
+        if spectrum.ndim != 2:
+            raise exceptions.ValidationError(
+                "`spectrum` must be a two-dimensional array."
+            )
+        if lambda_values.ndim != 1:
+            raise exceptions.ValidationError(
+                "`lambda_values` must be a one-dimensional array."
+            )
+        if phonon_smearing.ndim != 1:
+            raise exceptions.ValidationError(
+                "`phonon_smearing` must be a one-dimensional array."
+            )
+        if spectrum.shape[0] != frequency.shape[0]:
+            raise exceptions.ValidationError(
+                "The first spectrum dimension must match the frequency grid length."
+            )
+        if lambda_values.shape != phonon_smearing.shape:
+            raise exceptions.ValidationError(
+                "`lambda_values` and `phonon_smearing` must have the same shape."
+            )
+
+        num_smearings = lambda_values.shape[0]
+
+        if cumulative_lambda is not None:
+            if cumulative_lambda.ndim != 2:
+                raise exceptions.ValidationError(
+                    "`cumulative_lambda` must be a two-dimensional array."
+                )
+            if cumulative_lambda.shape != spectrum.shape:
+                raise exceptions.ValidationError(
+                    "`cumulative_lambda` must have the same shape as `spectrum`."
+                )
+            raw_spectrum = numpy.concatenate([spectrum, cumulative_lambda], axis=1)
+            spectrum_data = spectrum
+        elif spectrum.shape[1] == num_smearings:
+            raw_spectrum = spectrum
+            spectrum_data = spectrum
+            cumulative_lambda = None
+        elif spectrum.shape[1] == 2 * num_smearings:
+            spectrum_data = spectrum[:, :num_smearings]
+            cumulative_lambda = spectrum[:, num_smearings:]
+            raw_spectrum = spectrum
+        else:
+            raise exceptions.ValidationError(
+                "The spectrum must have either one or two blocks of columns per smearing value."
+            )
+
+        self.set_array(self.ARRAY_FREQUENCY, frequency)
+        self.set_array(self.ARRAY_RAW_SPECTRUM, raw_spectrum)
+        self.set_array(self.ARRAY_SPECTRUM, spectrum_data)
+        self.set_array(self.ARRAY_LAMBDA, lambda_values)
+        self.set_array(self.ARRAY_PHONON_SMEARING, phonon_smearing)
+        if cumulative_lambda is None:
+            self._delete_optional_array(self.ARRAY_CUMULATIVE_LAMBDA)
+        else:
+            self.set_array(self.ARRAY_CUMULATIVE_LAMBDA, cumulative_lambda)
+
+        self._set_optional_attribute(
+            self.ATTRIBUTE_ELECTRON_SMEARING, electron_smearing
+        )
+        self._set_optional_attribute(self.ATTRIBUTE_FERMI_WINDOW, fermi_window)
+        self._set_optional_attribute(
+            self.ATTRIBUTE_SUMMED_ELPH_COUPLING, summed_elph_coupling
+        )
+
+    def get_frequency(self):
+        """Return the frequency grid in meV."""
+        return self.get_array(self.ARRAY_FREQUENCY)
+
+    def get_spectrum(self):
+        """Return the a2F spectrum values."""
+        return self.get_array(self.ARRAY_SPECTRUM)
+
+    def get_cumulative_lambda(self):
+        """Return the cumulative integrated lambda spectrum if available."""
+        if self.ARRAY_CUMULATIVE_LAMBDA not in self.get_arraynames():
+            return None
+
+        return self.get_array(self.ARRAY_CUMULATIVE_LAMBDA)
+
+    def get_lambda(self):
+        """Return the integrated electron-phonon coupling values."""
+        return self.get_array(self.ARRAY_LAMBDA)
+
+    def get_phonon_smearing(self):
+        """Return the phonon smearing grid in meV."""
+        return self.get_array(self.ARRAY_PHONON_SMEARING)
+
+    @property
+    def electron_smearing(self):
+        """Return the electron smearing in eV if available."""
+        return self.base.attributes.get(self.ATTRIBUTE_ELECTRON_SMEARING, None)
+
+    @property
+    def fermi_window(self):
+        """Return the Fermi window in eV if available."""
+        return self.base.attributes.get(self.ATTRIBUTE_FERMI_WINDOW, None)
+
+    @property
+    def summed_elph_coupling(self):
+        """Return the summed electron-phonon coupling if available."""
+        return self.base.attributes.get(self.ATTRIBUTE_SUMMED_ELPH_COUPLING, None)
+
+    def _set_optional_attribute(self, key, value):
+        """Set or clear an optional scalar attribute."""
+        if value is None:
+            try:
+                self.base.attributes.delete(key)
+            except AttributeError:
+                pass
+            return
+
+        self.base.attributes.set(key, float(value))
+
+    def _delete_optional_array(self, name):
+        """Delete an optional array if it exists."""
+        if name in self.get_arraynames():
+            self.delete_array(name)

--- a/src/aiida_epw/data/gap_function.py
+++ b/src/aiida_epw/data/gap_function.py
@@ -1,0 +1,100 @@
+"""Domain-specific data type for EPW gap-function tables."""
+
+import numpy
+from aiida import orm
+from aiida.common import exceptions
+
+
+class GapFunctionData(orm.ArrayData):
+    """Store a temperature-indexed collection of EPW gap-function tables."""
+
+    ATTRIBUTE_TEMPERATURES = "temperatures"
+    ATTRIBUTE_ARRAY_NAMES = "array_names"
+    ATTRIBUTE_KIND = "kind"
+    ARRAY_NAME_TEMPLATE = "gap_function_{index:03d}"
+
+    def set_gap_functions(self, gap_functions, *, kind=None):
+        """Store gap-function tables keyed by temperature."""
+        if not gap_functions:
+            raise exceptions.ValidationError("`gap_functions` cannot be empty.")
+
+        normalized = []
+        for temperature, gap_function in sorted(
+            gap_functions.items(), key=lambda item: float(item[0])
+        ):
+            table = numpy.array(gap_function, dtype=float)
+            if table.ndim != 2:
+                raise exceptions.ValidationError(
+                    "Each gap-function entry must be a two-dimensional array."
+                )
+            normalized.append((float(temperature), table))
+
+        self._delete_gap_function_arrays()
+
+        temperatures = []
+        array_names = []
+        for index, (temperature, table) in enumerate(normalized):
+            array_name = self.ARRAY_NAME_TEMPLATE.format(index=index)
+            self.set_array(array_name, table)
+            temperatures.append(temperature)
+            array_names.append(array_name)
+
+        self.base.attributes.set(self.ATTRIBUTE_TEMPERATURES, temperatures)
+        self.base.attributes.set(self.ATTRIBUTE_ARRAY_NAMES, array_names)
+        self._set_optional_attribute(self.ATTRIBUTE_KIND, kind)
+
+    def get_temperatures(self):
+        """Return the stored temperatures in Kelvin."""
+        return numpy.array(
+            self.base.attributes.get(self.ATTRIBUTE_TEMPERATURES, []), dtype=float
+        )
+
+    def get_gap_functions(self):
+        """Return all stored gap-function tables keyed by temperature."""
+        return {
+            temperature: self.get_array(array_name)
+            for temperature, array_name in self._get_temperature_array_pairs()
+        }
+
+    def get_gap_function(self, temperature, *, atol=1e-8):
+        """Return the gap-function table for a specific temperature."""
+        target = float(temperature)
+
+        for stored_temperature, array_name in self._get_temperature_array_pairs():
+            if numpy.isclose(stored_temperature, target, atol=atol, rtol=0.0):
+                return self.get_array(array_name)
+
+        raise KeyError(f"No gap function stored for temperature {target}.")
+
+    def get_itergap_functions(self):
+        """Yield `(temperature, table)` pairs in ascending temperature order."""
+        for temperature, array_name in self._get_temperature_array_pairs():
+            yield temperature, self.get_array(array_name)
+
+    @property
+    def kind(self):
+        """Return the optional gap-function kind, e.g. `iso` or `aniso`."""
+        return self.base.attributes.get(self.ATTRIBUTE_KIND, None)
+
+    def _get_temperature_array_pairs(self):
+        """Return the stored temperature-to-array mapping."""
+        temperatures = self.base.attributes.get(self.ATTRIBUTE_TEMPERATURES, [])
+        array_names = self.base.attributes.get(self.ATTRIBUTE_ARRAY_NAMES, [])
+        return list(zip(temperatures, array_names, strict=True))
+
+    def _delete_gap_function_arrays(self):
+        """Delete previously stored gap-function tables."""
+        for array_name in self.base.attributes.get(self.ATTRIBUTE_ARRAY_NAMES, []):
+            if array_name in self.get_arraynames():
+                self.delete_array(array_name)
+
+    def _set_optional_attribute(self, key, value):
+        """Set or clear an optional scalar attribute."""
+        if value is None:
+            try:
+                self.base.attributes.delete(key)
+            except AttributeError:
+                pass
+            return
+
+        self.base.attributes.set(key, value)

--- a/src/aiida_epw/data/lambda_fs.py
+++ b/src/aiida_epw/data/lambda_fs.py
@@ -1,0 +1,70 @@
+"""Domain-specific data type for EPW Fermi-surface electron-phonon couplings."""
+
+import numpy
+from aiida import orm
+from aiida.common import exceptions
+
+
+class LambdaFSData(orm.ArrayData):
+    """Store the EPW ``lambda_FS`` table with explicit semantic getters."""
+
+    ARRAY_KPOINTS = "kpoints"
+    ARRAY_BANDS = "band"
+    ARRAY_ENERGIES = "energy"
+    ARRAY_LAMBDA = "lambda"
+    LEGACY_ARRAY_ENERGIES = "Enk"
+
+    ATTRIBUTE_ENERGY_UNITS = "energy_units"
+
+    def set_lambda_fs(self, kpoints, bands, energies, couplings, *, energy_units="eV"):
+        """Store the Fermi-surface coupling table."""
+        kpoints = numpy.array(kpoints, dtype=float)
+        bands = numpy.array(bands, dtype=float)
+        energies = numpy.array(energies, dtype=float)
+        couplings = numpy.array(couplings, dtype=float)
+
+        if kpoints.ndim != 2 or kpoints.shape[1] != 3:
+            raise exceptions.ValidationError(
+                "`kpoints` must be a two-dimensional array with shape (N, 3)."
+            )
+        for name, array in (
+            ("bands", bands),
+            ("energies", energies),
+            ("couplings", couplings),
+        ):
+            if array.ndim != 1:
+                raise exceptions.ValidationError(
+                    f"`{name}` must be a one-dimensional array."
+                )
+            if array.shape[0] != kpoints.shape[0]:
+                raise exceptions.ValidationError(
+                    f"`{name}` must have the same length as `kpoints`."
+                )
+
+        self.set_array(self.ARRAY_KPOINTS, kpoints)
+        self.set_array(self.ARRAY_BANDS, bands)
+        self.set_array(self.ARRAY_ENERGIES, energies)
+        self.set_array(self.LEGACY_ARRAY_ENERGIES, energies)
+        self.set_array(self.ARRAY_LAMBDA, couplings)
+        self.base.attributes.set(self.ATTRIBUTE_ENERGY_UNITS, energy_units)
+
+    def get_kpoints(self):
+        """Return the k-points."""
+        return self.get_array(self.ARRAY_KPOINTS)
+
+    def get_bands(self):
+        """Return the band indices."""
+        return self.get_array(self.ARRAY_BANDS)
+
+    def get_energies(self):
+        """Return the band energies."""
+        return self.get_array(self.ARRAY_ENERGIES)
+
+    def get_lambda(self):
+        """Return the electron-phonon couplings."""
+        return self.get_array(self.ARRAY_LAMBDA)
+
+    @property
+    def energy_units(self):
+        """Return the energy units."""
+        return self.base.attributes.get(self.ATTRIBUTE_ENERGY_UNITS)

--- a/src/aiida_epw/data/lambda_k_pairs.py
+++ b/src/aiida_epw/data/lambda_k_pairs.py
@@ -1,0 +1,39 @@
+"""Domain-specific data type for EPW ``lambda_k_pairs`` spectra."""
+
+import numpy
+from aiida import orm
+from aiida.common import exceptions
+
+
+class LambdaKPairsData(orm.ArrayData):
+    """Store the EPW ``lambda_k_pairs`` distribution with explicit getters."""
+
+    ARRAY_LAMBDA_NK = "lambda_nk"
+    ARRAY_RHO = "rho"
+
+    def set_lambda_k_pairs(self, lambda_nk, rho):
+        """Store the EPW ``lambda_k_pairs`` columns."""
+        lambda_nk = numpy.array(lambda_nk, dtype=float)
+        rho = numpy.array(rho, dtype=float)
+
+        if lambda_nk.ndim != 1:
+            raise exceptions.ValidationError(
+                "`lambda_nk` must be a one-dimensional array."
+            )
+        if rho.ndim != 1:
+            raise exceptions.ValidationError("`rho` must be a one-dimensional array.")
+        if lambda_nk.shape != rho.shape:
+            raise exceptions.ValidationError(
+                "`lambda_nk` and `rho` must have the same shape."
+            )
+
+        self.set_array(self.ARRAY_LAMBDA_NK, lambda_nk)
+        self.set_array(self.ARRAY_RHO, rho)
+
+    def get_lambda_nk(self):
+        """Return the lambda_nk grid."""
+        return self.get_array(self.ARRAY_LAMBDA_NK)
+
+    def get_rho(self):
+        """Return the density distribution."""
+        return self.get_array(self.ARRAY_RHO)

--- a/src/aiida_epw/data/projected_spectrum.py
+++ b/src/aiida_epw/data/projected_spectrum.py
@@ -1,0 +1,144 @@
+"""Domain-specific data type for EPW projected spectra."""
+
+import numpy
+from aiida import orm
+from aiida.common import exceptions
+
+
+class ProjectedSpectrumData(orm.ArrayData):
+    """Store a projected spectrum with explicit grid and split total/projected series."""
+
+    ARRAY_GRID = "grid"
+    ARRAY_SERIES = "series"
+    ARRAY_TOTAL = "total"
+    ARRAY_PROJECTED = "projected"
+
+    ATTRIBUTE_KIND = "kind"
+    ATTRIBUTE_GRID_NAME = "grid_name"
+    ATTRIBUTE_SERIES_NAME = "series_name"
+    ATTRIBUTE_TOTAL_LABEL = "total_label"
+    ATTRIBUTE_PROJECTED_LABEL = "projected_label"
+    ATTRIBUTE_LEGACY_GRID_NAME = "legacy_grid_name"
+    ATTRIBUTE_LEGACY_SERIES_NAME = "legacy_series_name"
+
+    def set_projected_spectrum(
+        self,
+        grid,
+        series,
+        *,
+        kind,
+        grid_name=None,
+        series_name=None,
+        total_label=None,
+        projected_label=None,
+        legacy_grid_name=None,
+        legacy_series_name=None,
+    ):
+        """Store a projected spectrum and split off the total series."""
+        grid = numpy.array(grid, dtype=float)
+        series = numpy.array(series, dtype=float)
+
+        if grid.ndim != 1:
+            raise exceptions.ValidationError("`grid` must be a one-dimensional array.")
+        if series.ndim != 2:
+            raise exceptions.ValidationError(
+                "`series` must be a two-dimensional array."
+            )
+        if series.shape[0] != grid.shape[0]:
+            raise exceptions.ValidationError(
+                "The first spectrum dimension must match the grid length."
+            )
+        if series.shape[1] < 1:
+            raise exceptions.ValidationError(
+                "The spectrum must contain at least one series column."
+            )
+
+        self._delete_alias_array(
+            self.base.attributes.get(self.ATTRIBUTE_LEGACY_GRID_NAME, None)
+        )
+        self._delete_alias_array(
+            self.base.attributes.get(self.ATTRIBUTE_LEGACY_SERIES_NAME, None)
+        )
+
+        self.set_array(self.ARRAY_GRID, grid)
+        self.set_array(self.ARRAY_SERIES, series)
+        self.set_array(self.ARRAY_TOTAL, series[:, 0])
+        if series.shape[1] == 1:
+            self._delete_alias_array(self.ARRAY_PROJECTED)
+        else:
+            self.set_array(self.ARRAY_PROJECTED, series[:, 1:])
+
+        if legacy_grid_name is not None:
+            self.set_array(legacy_grid_name, grid)
+        if legacy_series_name is not None:
+            self.set_array(legacy_series_name, series)
+
+        self.base.attributes.set(self.ATTRIBUTE_KIND, kind)
+        self._set_optional_attribute(self.ATTRIBUTE_GRID_NAME, grid_name)
+        self._set_optional_attribute(self.ATTRIBUTE_SERIES_NAME, series_name)
+        self._set_optional_attribute(self.ATTRIBUTE_TOTAL_LABEL, total_label)
+        self._set_optional_attribute(self.ATTRIBUTE_PROJECTED_LABEL, projected_label)
+        self._set_optional_attribute(self.ATTRIBUTE_LEGACY_GRID_NAME, legacy_grid_name)
+        self._set_optional_attribute(
+            self.ATTRIBUTE_LEGACY_SERIES_NAME, legacy_series_name
+        )
+
+    def get_grid(self):
+        """Return the spectrum grid."""
+        return self.get_array(self.ARRAY_GRID)
+
+    def get_series(self):
+        """Return the combined total-plus-projected spectrum matrix."""
+        return self.get_array(self.ARRAY_SERIES)
+
+    def get_total(self):
+        """Return the total spectrum."""
+        return self.get_array(self.ARRAY_TOTAL)
+
+    def get_projected(self):
+        """Return the projected spectrum columns, if present."""
+        if self.ARRAY_PROJECTED not in self.get_arraynames():
+            return None
+
+        return self.get_array(self.ARRAY_PROJECTED)
+
+    @property
+    def kind(self):
+        """Return the spectrum kind, e.g. `a2f_proj` or `phdos_proj`."""
+        return self.base.attributes.get(self.ATTRIBUTE_KIND)
+
+    @property
+    def grid_name(self):
+        """Return the semantic name of the grid."""
+        return self.base.attributes.get(self.ATTRIBUTE_GRID_NAME, None)
+
+    @property
+    def series_name(self):
+        """Return the semantic name of the combined series block."""
+        return self.base.attributes.get(self.ATTRIBUTE_SERIES_NAME, None)
+
+    @property
+    def total_label(self):
+        """Return the label of the total spectrum column."""
+        return self.base.attributes.get(self.ATTRIBUTE_TOTAL_LABEL, None)
+
+    @property
+    def projected_label(self):
+        """Return the label of the projected spectrum block."""
+        return self.base.attributes.get(self.ATTRIBUTE_PROJECTED_LABEL, None)
+
+    def _delete_alias_array(self, name):
+        """Delete an alias array if it exists."""
+        if name and name in self.get_arraynames():
+            self.delete_array(name)
+
+    def _set_optional_attribute(self, key, value):
+        """Set or clear an optional scalar attribute."""
+        if value is None:
+            try:
+                self.base.attributes.delete(key)
+            except AttributeError:
+                pass
+            return
+
+        self.base.attributes.set(key, value)

--- a/tests/data/test_a2f.py
+++ b/tests/data/test_a2f.py
@@ -1,0 +1,71 @@
+"""Tests for the ``A2fData`` datatype."""
+
+import numpy
+import pytest
+from aiida.common import exceptions
+from aiida.plugins import DataFactory
+
+from aiida_epw.data import A2fData
+
+
+def test_a2f_data_roundtrip():
+    """Test storing and retrieving an a2F spectrum."""
+    node = A2fData()
+    node.set_a2f_data(
+        frequency=[0.1, 0.2],
+        spectrum=[[1.0, 2.0], [3.0, 4.0]],
+        lambda_values=[0.5, 0.6],
+        phonon_smearing=[0.01, 0.02],
+        electron_smearing=0.05,
+        fermi_window=0.8,
+        summed_elph_coupling=1.2,
+    )
+
+    assert node.get_frequency().tolist() == [0.1, 0.2]
+    assert node.get_spectrum().tolist() == [[1.0, 2.0], [3.0, 4.0]]
+    assert node.get_cumulative_lambda() is None
+    assert node.get_lambda().tolist() == [0.5, 0.6]
+    assert node.get_phonon_smearing().tolist() == [0.01, 0.02]
+    assert node.get_array("degaussq").tolist() == [0.01, 0.02]
+    assert node.electron_smearing == pytest.approx(0.05)
+    assert node.fermi_window == pytest.approx(0.8)
+    assert node.summed_elph_coupling == pytest.approx(1.2)
+
+
+def test_a2f_data_splits_legacy_combined_columns():
+    """Test the datatype can split EPW's combined `a2f` and cumulative lambda columns."""
+    node = A2fData()
+    node.set_a2f_data(
+        frequency=[0.1, 0.2],
+        spectrum=[
+            [1.0, 2.0, 0.1, 0.2],
+            [3.0, 4.0, 0.3, 0.4],
+        ],
+        lambda_values=[0.5, 0.6],
+        phonon_smearing=[0.01, 0.02],
+    )
+
+    assert node.get_array("a2f").tolist() == [
+        [1.0, 2.0, 0.1, 0.2],
+        [3.0, 4.0, 0.3, 0.4],
+    ]
+    assert node.get_spectrum().tolist() == [[1.0, 2.0], [3.0, 4.0]]
+    assert node.get_cumulative_lambda().tolist() == [[0.1, 0.2], [0.3, 0.4]]
+
+
+def test_a2f_data_validates_shape_contract():
+    """Test inconsistent a2F grids are rejected."""
+    node = A2fData()
+
+    with pytest.raises(exceptions.ValidationError):
+        node.set_a2f_data(
+            frequency=numpy.array([0.1, 0.2]),
+            spectrum=numpy.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+            lambda_values=numpy.array([0.5]),
+            phonon_smearing=numpy.array([0.01]),
+        )
+
+
+def test_a2f_data_entry_point():
+    """Test the datatype is registered through ``aiida.data``."""
+    assert DataFactory("epw.a2f") is A2fData

--- a/tests/data/test_gap_function.py
+++ b/tests/data/test_gap_function.py
@@ -1,0 +1,60 @@
+"""Tests for the ``GapFunctionData`` datatype."""
+
+import numpy
+import pytest
+from aiida.common import exceptions
+from aiida.plugins import DataFactory
+
+from aiida_epw.data import GapFunctionData
+
+
+def test_gap_function_data_roundtrip():
+    """Test storing and retrieving gap-function tables by temperature."""
+    node = GapFunctionData()
+    node.set_gap_functions(
+        {
+            5.0: [[0.4, 1.0], [0.8, 0.7]],
+            3.0: [[0.2, 1.3], [0.6, 0.9]],
+        },
+        kind="iso",
+    )
+
+    assert node.kind == "iso"
+    assert node.get_temperatures().tolist() == [3.0, 5.0]
+    assert node.get_gap_function(3.0).tolist() == [[0.2, 1.3], [0.6, 0.9]]
+    assert list(node.get_gap_functions()) == [3.0, 5.0]
+    assert [
+        (temperature, table.tolist())
+        for temperature, table in node.get_itergap_functions()
+    ] == [
+        (3.0, [[0.2, 1.3], [0.6, 0.9]]),
+        (5.0, [[0.4, 1.0], [0.8, 0.7]]),
+    ]
+
+
+def test_gap_function_data_replaces_previous_tables():
+    """Test resetting gap functions drops stale arrays from a previous payload."""
+    node = GapFunctionData()
+    node.set_gap_functions({3.0: [[0.1, 0.2]]}, kind="iso")
+    node.set_gap_functions({4.0: [[0.3, 0.4], [0.5, 0.6]]}, kind="aniso")
+
+    assert node.kind == "aniso"
+    assert node.get_temperatures().tolist() == [4.0]
+    assert node.get_gap_function(4.0).tolist() == [[0.3, 0.4], [0.5, 0.6]]
+    assert node.get_arraynames() == ["gap_function_000"]
+
+
+def test_gap_function_data_validates_shape_contract():
+    """Test invalid gap-function payloads are rejected."""
+    node = GapFunctionData()
+
+    with pytest.raises(exceptions.ValidationError):
+        node.set_gap_functions({})
+
+    with pytest.raises(exceptions.ValidationError):
+        node.set_gap_functions({3.0: numpy.array([0.1, 0.2])})
+
+
+def test_gap_function_data_entry_point():
+    """Test the datatype is registered through ``aiida.data``."""
+    assert DataFactory("epw.gap_function") is GapFunctionData

--- a/tests/data/test_lambda_fs.py
+++ b/tests/data/test_lambda_fs.py
@@ -1,0 +1,52 @@
+"""Tests for the ``LambdaFSData`` datatype."""
+
+import numpy
+import pytest
+from aiida.common import exceptions
+from aiida.plugins import DataFactory
+
+from aiida_epw.data import LambdaFSData
+
+
+def test_lambda_fs_roundtrip():
+    """Test storing and retrieving a lambda_FS table."""
+    node = LambdaFSData()
+    node.set_lambda_fs(
+        kpoints=[[0.0, 0.1, 0.2], [0.5, 0.6, 0.7]],
+        bands=[1, 2],
+        energies=[0.3, 0.4],
+        couplings=[0.9, 1.1],
+    )
+
+    assert node.energy_units == "eV"
+    assert node.get_kpoints().tolist() == [[0.0, 0.1, 0.2], [0.5, 0.6, 0.7]]
+    assert node.get_bands().tolist() == [1.0, 2.0]
+    assert node.get_energies().tolist() == [0.3, 0.4]
+    assert node.get_lambda().tolist() == [0.9, 1.1]
+    assert node.get_array("Enk").tolist() == [0.3, 0.4]
+
+
+def test_lambda_fs_validates_shape_contract():
+    """Test invalid lambda_FS payloads are rejected."""
+    node = LambdaFSData()
+
+    with pytest.raises(exceptions.ValidationError):
+        node.set_lambda_fs(
+            kpoints=numpy.array([0.0, 0.1, 0.2]),
+            bands=[1],
+            energies=[0.3],
+            couplings=[0.9],
+        )
+
+    with pytest.raises(exceptions.ValidationError):
+        node.set_lambda_fs(
+            kpoints=[[0.0, 0.1, 0.2], [0.5, 0.6, 0.7]],
+            bands=[1],
+            energies=[0.3, 0.4],
+            couplings=[0.9, 1.1],
+        )
+
+
+def test_lambda_fs_entry_point():
+    """Test the datatype is registered through ``aiida.data``."""
+    assert DataFactory("epw.lambda_fs") is LambdaFSData

--- a/tests/data/test_lambda_k_pairs.py
+++ b/tests/data/test_lambda_k_pairs.py
@@ -1,0 +1,34 @@
+"""Tests for the ``LambdaKPairsData`` datatype."""
+
+import pytest
+from aiida.common import exceptions
+from aiida.plugins import DataFactory
+
+from aiida_epw.data import LambdaKPairsData
+
+
+def test_lambda_k_pairs_roundtrip():
+    """Test storing and retrieving a lambda_k_pairs distribution."""
+    node = LambdaKPairsData()
+    node.set_lambda_k_pairs(lambda_nk=[0.1, 0.2], rho=[1.0, 1.5])
+
+    assert node.get_lambda_nk().tolist() == [0.1, 0.2]
+    assert node.get_rho().tolist() == [1.0, 1.5]
+    assert node.get_array("lambda_nk").tolist() == [0.1, 0.2]
+    assert node.get_array("rho").tolist() == [1.0, 1.5]
+
+
+def test_lambda_k_pairs_validates_shape_contract():
+    """Test invalid lambda_k_pairs payloads are rejected."""
+    node = LambdaKPairsData()
+
+    with pytest.raises(exceptions.ValidationError):
+        node.set_lambda_k_pairs(lambda_nk=[[0.1]], rho=[1.0])
+
+    with pytest.raises(exceptions.ValidationError):
+        node.set_lambda_k_pairs(lambda_nk=[0.1, 0.2], rho=[1.0])
+
+
+def test_lambda_k_pairs_entry_point():
+    """Test the datatype is registered through ``aiida.data``."""
+    assert DataFactory("epw.lambda_k_pairs") is LambdaKPairsData

--- a/tests/data/test_projected_spectrum.py
+++ b/tests/data/test_projected_spectrum.py
@@ -1,0 +1,63 @@
+"""Tests for the ``ProjectedSpectrumData`` datatype."""
+
+import numpy
+import pytest
+from aiida.common import exceptions
+from aiida.plugins import DataFactory
+
+from aiida_epw.data import ProjectedSpectrumData
+
+
+def test_projected_spectrum_roundtrip():
+    """Test storing and retrieving a projected spectrum."""
+    node = ProjectedSpectrumData()
+    node.set_projected_spectrum(
+        grid=[0.1, 0.2],
+        series=[[1.0, 0.7, 0.3], [2.0, 1.4, 0.6]],
+        kind="phdos_proj",
+        grid_name="frequency",
+        series_name="phdos_proj",
+        total_label="phdos",
+        projected_label="phdos_modeproj",
+        legacy_grid_name="Frequency",
+        legacy_series_name="PHDOS_proj",
+    )
+
+    assert node.kind == "phdos_proj"
+    assert node.grid_name == "frequency"
+    assert node.series_name == "phdos_proj"
+    assert node.total_label == "phdos"
+    assert node.projected_label == "phdos_modeproj"
+    assert node.get_grid().tolist() == [0.1, 0.2]
+    assert node.get_total().tolist() == [1.0, 2.0]
+    assert node.get_projected().tolist() == [[0.7, 0.3], [1.4, 0.6]]
+    assert node.get_series().tolist() == [[1.0, 0.7, 0.3], [2.0, 1.4, 0.6]]
+    assert node.get_array("Frequency").tolist() == [0.1, 0.2]
+    assert node.get_array("PHDOS_proj").tolist() == [[1.0, 0.7, 0.3], [2.0, 1.4, 0.6]]
+
+
+def test_projected_spectrum_without_explicit_projected_block():
+    """Test single-column spectra do not expose a projected block."""
+    node = ProjectedSpectrumData()
+    node.set_projected_spectrum(grid=[0.1, 0.2], series=[[1.0], [2.0]], kind="test")
+
+    assert node.get_total().tolist() == [1.0, 2.0]
+    assert node.get_projected() is None
+
+
+def test_projected_spectrum_validates_shape_contract():
+    """Test invalid projected spectrum payloads are rejected."""
+    node = ProjectedSpectrumData()
+
+    with pytest.raises(exceptions.ValidationError):
+        node.set_projected_spectrum(grid=[[0.1]], series=[[1.0]], kind="broken")
+
+    with pytest.raises(exceptions.ValidationError):
+        node.set_projected_spectrum(
+            grid=[0.1, 0.2], series=numpy.array([1.0, 2.0]), kind="broken"
+        )
+
+
+def test_projected_spectrum_entry_point():
+    """Test the datatype is registered through ``aiida.data``."""
+    assert DataFactory("epw.projected_spectrum") is ProjectedSpectrumData


### PR DESCRIPTION
This PR introduces custom aiida.data types for parsed EPW output data. 

### Implemented Datatypes
The following five custom data classes are introduced under `src/aiida_epw/data/`:
1. **`A2fData`** (`epw.a2f`): Eliashberg spectral function $\alpha^2F(\omega)$ data.
2. **`GapFunctionData`** (`epw.gap_function`): superconducting gap function.
3. **`LambdaFSData`** (`epw.lambda_fs`): electron-phonon coupling strength on the Fermi surface.
4. **`LambdaKPairsData`** (`epw.lambda_k_pairs`): momentum-resolved anisotropic electron-phonon coupling matrices.
5. **`ProjectedSpectrumData`** (`epw.projected_spectrum`): projected Eliashberg spectral functions.
### Key Changes
- Created data module files under `src/aiida_epw/data/` and exposed them in `__init__.py`.
- Registered the new data classes as AiiDA entry points in `pyproject.toml` under `[project.entry-points.'aiida.data']`.
- Added unit tests under `tests/data/` for instantiation, serialization, entry-point retrieval, and round-trip data integrity.
### Verification Results
All 18 newly introduced datatype tests pass successfully locally:
```bash
$ pytest tests/data/
======================== 18 passed, 1 warning in 0.14s =========================