### PR TITLE
🐛 `EpwPrepWorkChain`: Remove `metadata` namespace.

### DIFF
--- a/src/aiida_epw/workflows/base.py
+++ b/src/aiida_epw/workflows/base.py
@@ -242,18 +242,15 @@ class EpwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
             parameter_overrides = overrides.get("parameters", {})
             parameters = recursive_merge(parameters, parameter_overrides)
 
-        metadata = inputs.pop("metadata")
-
         if options:
-            metadata["options"] = recursive_merge(metadata["options"], options)
+            inputs["options"] = recursive_merge(inputs["options"], options)
 
         # pylint: disable=no-member
         builder = cls.get_builder()
         builder.structure = structure
         builder.code = code
         builder.parameters = orm.Dict(parameters)
-        ## Must firstly pop the options from the metadata dictionary.
-        builder.options = metadata.pop("options")
+        builder.options = orm.Dict(inputs["options"])
 
         if w90_chk_to_ukk_script:
             type_check(w90_chk_to_ukk_script, orm.RemoteData)


### PR DESCRIPTION
Remove the `metadata` namespace in the builder in `EpwBaseWorkChain` since we directly expose the `EpwCalculation` namespace at the top level of `EpwBaseWorkChain` 