### PR TITLE
♻️  `EpwPrepWorkChain`: get `target_base` using tool function

### DIFF
--- a/src/aiida_epw/tools/workchain.py
+++ b/src/aiida_epw/tools/workchain.py
@@ -312,7 +312,7 @@ def format_subprocess_failure(node, process_label=None):
     return message
 
 
-def get_target_basepath(computer):
+def get_default_target_basepath(computer):
     """Set the target basepath for the stash folder."""
     from pathlib import Path
 

--- a/src/aiida_epw/workflows/prep.py
+++ b/src/aiida_epw/workflows/prep.py
@@ -1,7 +1,6 @@
 """Work chain for doing the coarse-grid calculations."""
 
 import logging
-from pathlib import Path
 
 from aiida import orm
 from aiida.common import AttributeDict
@@ -529,6 +528,7 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
         builder = cls.get_builder()
         builder.structure = structure
 
+        # Construction of builder for the Wannier90BandsWorkChain or Wannier90OptimizedStructureWorkChain
         w90_bands_inputs = inputs.get("w90_bands", {})
         pseudo_family = inputs.pop("pseudo_family", None)
         manual_wannierization = kwargs.pop("manual_wannierization", None)
@@ -659,6 +659,7 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
 
         builder.w90_bands = w90_bands
 
+        # Construction of builder for `PhBaseWorkChain`
         if bandplot:
             builder.pop("ph_base", None)
         else:
@@ -670,37 +671,23 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
             ph_base.pop("qpoints_distance")
             builder.ph_base = ph_base
 
+        # Construction of builder for `EPWBaseWorkChain`s
         epw_builder_namespaces = ("epw_base", "epw_bands")
         for namespace in epw_builder_namespaces:
             epw_inputs = inputs.get(namespace, None)
             if epw_inputs is None:
                 continue
 
-            epw_options = epw_inputs.get("options")
-            if epw_options is None:
-                epw_options = epw_inputs.get("metadata", {}).get("options")
+            epw_options = epw_inputs.setdefault("options", {})
 
             if namespace == "epw_base":
-                stash_options = epw_options.get("stash", {}) if epw_options else {}
+                stash_options = epw_options.setdefault("stash", {})
                 if "target_base" not in stash_options:
-                    epw_computer = codes["epw"].computer
-                    target_basepath = None
-                    if epw_computer.transport_type == "core.local":
-                        target_basepath = Path(
-                            epw_computer.get_workdir(), "stash"
-                        ).as_posix()
-                    elif epw_computer.transport_type == "core.ssh":
-                        target_basepath = Path(
-                            epw_computer.get_workdir().format(
-                                username=epw_computer.get_configuration()["username"]
-                            ),
-                            "stash",
-                        ).as_posix()
+                    from aiida_epw.tools.workchain import get_default_target_basepath
 
-                    if epw_options is not None and target_basepath is not None:
-                        epw_options.setdefault("stash", {})["target_base"] = (
-                            target_basepath
-                        )
+                    target_basepath = get_default_target_basepath(codes["epw"].computer)
+                    if target_basepath:
+                        stash_options["target_base"] = target_basepath
 
             epw_builder = EpwBaseWorkChain.get_builder_from_protocol(
                 code=codes["epw"],

--- a/src/aiida_epw/workflows/prep.py
+++ b/src/aiida_epw/workflows/prep.py
@@ -697,10 +697,13 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
                             "stash",
                         ).as_posix()
 
-                    if epw_options is not None and target_basepath is not None:
-                        epw_options.setdefault("stash", {})["target_base"] = (
-                            target_basepath
-                        )
+                    if target_basepath is not None:
+                        if epw_options is None:
+                            epw_options = epw_inputs.setdefault("options", {})
+                        stash = epw_options.setdefault("stash", {})
+                        stash["target_base"] = target_basepath
+                        if stash.get("stash_mode", None) != "copy":
+                            stash["stash_mode"] = "copy"
 
             epw_builder = EpwBaseWorkChain.get_builder_from_protocol(
                 code=codes["epw"],

--- a/src/aiida_epw/workflows/protocols/prep.yaml
+++ b/src/aiida_epw/workflows/protocols/prep.yaml
@@ -32,6 +32,7 @@ default_inputs:
       max_wallclock_seconds: 43200  # Twelve hours
       withmpi: True
       stash:
+        stash_mode: copy
         source_list:
           - crystal.fmt
           - dmedata.fmt

--- a/src/aiida_epw/workflows/protocols/prep_mob.yaml
+++ b/src/aiida_epw/workflows/protocols/prep_mob.yaml
@@ -49,6 +49,7 @@ default_inputs:
       max_wallclock_seconds: 43200  # Twelve hours
       withmpi: True
       stash:
+        stash_mode: copy
         source_list:
           - crystal.fmt
           - dmedata.fmt

--- a/src/aiida_epw/workflows/protocols/prep_sc.yaml
+++ b/src/aiida_epw/workflows/protocols/prep_sc.yaml
@@ -32,6 +32,7 @@ default_inputs:
       max_wallclock_seconds: 43200  # Twelve hours
       withmpi: True
       stash:
+        stash_mode: copy
         source_list:
           - crystal.fmt
           - dmedata.fmt

--- a/tests/tools/test_workchain.py
+++ b/tests/tools/test_workchain.py
@@ -191,3 +191,30 @@ def test_get_parent_ph_pw_calculation_walks_restart_chain():
     )
 
     assert get_parent_ph_pw_calculation(latest_ph_parent) is original_pw
+
+
+def test_get_default_target_basepath():
+    """Test get_default_target_basepath for local and ssh computers."""
+    from aiida_epw.tools.workchain import get_default_target_basepath
+
+    class MockLocalComputer:
+        transport_type = "core.local"
+
+        def get_workdir(self):
+            return "/tmp/workdir"
+
+    class MockSshComputer:
+        transport_type = "core.ssh"
+        label = "mock-ssh"
+
+        def get_workdir(self):
+            return "/remote/{username}"
+
+        def get_configuration(self):
+            return {"username": "testuser"}
+
+    local_computer = MockLocalComputer()
+    assert get_default_target_basepath(local_computer) == "/tmp/workdir/stash"
+
+    ssh_computer = MockSshComputer()
+    assert get_default_target_basepath(ssh_computer) == "/remote/testuser/stash"

--- a/tests/workflows/test_prep.py
+++ b/tests/workflows/test_prep.py
@@ -341,3 +341,71 @@ class TestWannier90Selection:
         )
 
         assert EpwPrepWorkChain._uses_wannier90_bands_workchain(dummy) is True
+
+
+class TestGetBuilderFromProtocol:
+    """Tests for `EpwPrepWorkChain.get_builder_from_protocol`."""
+
+    def test_stash_mode_copy_is_injected(self, fixture_code, generate_structure):
+        """Test that `stash_mode` = "copy" is injected when target_base is auto-injected."""
+        from unittest.mock import patch
+        from aiida_epw.workflows.prep import EpwPrepWorkChain
+        from aiida_wannier90_workflows.common.types import WannierProjectionType
+        from aiida.plugins import DataFactory
+        import io
+
+        UpfData = DataFactory("pseudo.upf")
+        dummy_upf = UpfData(
+            io.BytesIO(b'element="Si" z_valence="4.0"'), filename="Si.upf"
+        )
+        dummy_upf.store()
+
+        codes = {
+            "epw": fixture_code("epw.epw"),
+            "ph": fixture_code("quantumespresso.ph"),
+            "pw": fixture_code("quantumespresso.pw"),
+            "wannier90": fixture_code("wannier90.wannier90"),
+            "pw2wannier90": fixture_code("wannier90.pw2wannier90"),
+        }
+
+        from aiida_pseudo.groups.family import PseudoDojoFamily
+
+        family = PseudoDojoFamily(label="PseudoDojo/0.5/PBE/SR/standard/upf")
+        family.store()
+        family.add_nodes([dummy_upf])
+
+        structure = generate_structure()
+
+        with (
+            patch(
+                "aiida_wannier90_workflows.utils.pseudo.get_pseudo_and_cutoff"
+            ) as mock_get_pseudo,
+            patch(
+                "aiida_wannier90_workflows.utils.pseudo.get_wannier_number_of_bands"
+            ) as mock_get_bands,
+            patch(
+                "aiida_wannier90_workflows.utils.pseudo.get_number_of_projections"
+            ) as mock_get_projs,
+            patch(
+                "aiida_wannier90_workflows.utils.pseudo.get_pseudo_orbitals"
+            ) as mock_get_orbitals,
+            patch.object(PseudoDojoFamily, "get_recommended_cutoffs") as mock_cutoffs,
+            patch.object(PseudoDojoFamily, "get_pseudos") as mock_pseudos,
+        ):
+            mock_get_pseudo.return_value = ({"Si": dummy_upf}, 30.0, 120.0)
+            mock_get_bands.return_value = 8
+            mock_get_projs.return_value = 4
+            mock_get_orbitals.return_value = {"Si": {"pswfcs": [], "semicores": []}}
+            mock_cutoffs.return_value = (30.0, 120.0)
+            mock_pseudos.return_value = {"Si": dummy_upf}
+            builder = EpwPrepWorkChain.get_builder_from_protocol(
+                codes=codes,
+                structure=structure,
+                wannier_projection_type=WannierProjectionType.ANALYTIC,
+            )
+
+        # Verify that stash options have stash_mode = "copy" and target_basepath set
+        epw_base_options = builder.epw_base.options
+        assert "stash" in epw_base_options
+        assert epw_base_options["stash"]["stash_mode"] == "copy"
+        assert "target_base" in epw_base_options["stash"]


### PR DESCRIPTION
Refactor option/stash handling in `EpwPrepWorkChain` to avoid the legacy `metadata` namespace and use `get_default_target_basepath` to get the default setting of `target_basepath`.

Set the default `stash_mode` as copy to avoid crash of process.