### PR TITLE
🐛 `SuperConWorkChain`: change the source of structure

### DIFF
--- a/src/aiida_epw/workflows/supercon.py
+++ b/src/aiida_epw/workflows/supercon.py
@@ -248,8 +248,15 @@ class SuperConWorkChain(ProtocolMixin, WorkChain):
                 .first()
                 .node
             )
+            structure = parent_epw.inputs.structure
         elif parent_epw.process_label == "EpwBaseWorkChain":
             epw_source = parent_epw
+            try:
+                structure = parent_epw.inputs.structure
+            except AttributeError as exc:
+                raise ValueError(
+                    "The `parent_epw` (EpwBaseWorkChain) does not contain `structure` in its inputs."
+                ) from exc
         else:
             raise ValueError(f"Invalid parent_epw process: {parent_epw.process_label}")
 
@@ -268,7 +275,7 @@ class SuperConWorkChain(ProtocolMixin, WorkChain):
 
             epw_builder = EpwBaseWorkChain.get_builder_from_protocol(
                 code=epw_code,
-                structure=epw_source.inputs.structure,
+                structure=structure,
                 protocol=protocol,
                 overrides=epw_inputs,
             )
@@ -293,7 +300,7 @@ class SuperConWorkChain(ProtocolMixin, WorkChain):
 
         builder.convergence_threshold = orm.Float(inputs["convergence_threshold"])
         builder.always_run_final = orm.Bool(inputs.get("always_run_final", False))
-        builder.structure = parent_epw.inputs.structure
+        builder.structure = structure
         builder.parent_folder_epw = parent_folder_epw
         builder.clean_workdir = orm.Bool(inputs["clean_workdir"])
 

--- a/src/aiida_epw/workflows/supercon.py
+++ b/src/aiida_epw/workflows/supercon.py
@@ -265,7 +265,7 @@ class SuperConWorkChain(ProtocolMixin, WorkChain):
                 raise ValueError(
                     "The `epw_code` must be configured on the same computer as that where the `parent_epw` was run."
                 )
-            parent_folder_epw = epw_source.outputs.remote_folder
+            parent_folder_epw = epw_source.outputs.remote_stash
         else:
             # TODO: Add check to make sure parent_folder_epw is on same computer as epw_code
             pass

--- a/tests/workflows/test_supercon.py
+++ b/tests/workflows/test_supercon.py
@@ -42,7 +42,7 @@ def test_supercon_get_builder_from_protocol_prep(
 
     epw_code = fixture_code("epw.epw")
     structure = generate_structure()
-    remote_folder = generate_remote_data(fixture_localhost, "/tmp/remote_folder")
+    remote_stash = generate_remote_data(fixture_localhost, "/tmp/remote_stash")
 
     # Mock the EpwPrepWorkChain parent node
     parent_epw = MagicMock()
@@ -57,7 +57,7 @@ def test_supercon_get_builder_from_protocol_prep(
     epw_source.inputs.kpoints = orm.KpointsData()
     epw_source.inputs.qpoints = orm.KpointsData()
     epw_source.outputs = MagicMock()
-    epw_source.outputs.remote_folder = remote_folder
+    epw_source.outputs.remote_stash = remote_stash
 
     parent_epw.base.links.get_outgoing.return_value.first.return_value.node = epw_source
 
@@ -68,7 +68,7 @@ def test_supercon_get_builder_from_protocol_prep(
     )
 
     assert builder.structure is structure
-    assert builder.parent_folder_epw is remote_folder
+    assert builder.parent_folder_epw is remote_stash
 
 
 def test_supercon_get_builder_from_protocol_base_success(
@@ -89,7 +89,7 @@ def test_supercon_get_builder_from_protocol_base_success(
 
     epw_code = fixture_code("epw.epw")
     structure = generate_structure()
-    remote_folder = generate_remote_data(fixture_localhost, "/tmp/remote_folder")
+    remote_stash = generate_remote_data(fixture_localhost, "/tmp/remote_stash")
 
     # Mock the EpwBaseWorkChain parent node
     parent_epw = MagicMock()
@@ -100,7 +100,7 @@ def test_supercon_get_builder_from_protocol_base_success(
     parent_epw.inputs.kpoints = orm.KpointsData()
     parent_epw.inputs.qpoints = orm.KpointsData()
     parent_epw.outputs = MagicMock()
-    parent_epw.outputs.remote_folder = remote_folder
+    parent_epw.outputs.remote_stash = remote_stash
 
     builder = SuperConWorkChain.get_builder_from_protocol(
         epw_code=epw_code,
@@ -109,7 +109,7 @@ def test_supercon_get_builder_from_protocol_base_success(
     )
 
     assert builder.structure is structure
-    assert builder.parent_folder_epw is remote_folder
+    assert builder.parent_folder_epw is remote_stash
 
 
 def test_supercon_get_builder_from_protocol_base_failure(
@@ -129,7 +129,7 @@ def test_supercon_get_builder_from_protocol_base_failure(
     monkeypatch.setattr(EpwBaseWorkChain, "get_builder_from_protocol", mock_get_builder)
 
     epw_code = fixture_code("epw.epw")
-    remote_folder = generate_remote_data(fixture_localhost, "/tmp/remote_folder")
+    remote_stash = generate_remote_data(fixture_localhost, "/tmp/remote_stash")
 
     # Mock the EpwBaseWorkChain parent node without structure
     parent_epw = MagicMock()
@@ -141,7 +141,7 @@ def test_supercon_get_builder_from_protocol_base_failure(
     parent_epw.inputs.kpoints = orm.KpointsData()
     parent_epw.inputs.qpoints = orm.KpointsData()
     parent_epw.outputs = MagicMock()
-    parent_epw.outputs.remote_folder = remote_folder
+    parent_epw.outputs.remote_stash = remote_stash
 
     with pytest.raises(ValueError, match="does not contain `structure` in its inputs"):
         SuperConWorkChain.get_builder_from_protocol(

--- a/tests/workflows/test_supercon.py
+++ b/tests/workflows/test_supercon.py
@@ -1,0 +1,151 @@
+"""Tests for SuperConWorkChain."""
+
+from unittest.mock import MagicMock
+import pytest
+from aiida import orm
+
+
+class MockBuilder(dict):
+    def __getattr__(self, key):
+        if key == "get_dict":
+            return lambda: {}
+        if key == "get_list":
+            return lambda: []
+        return self.setdefault(key, MockBuilder())
+
+    def __setattr__(self, key, value):
+        self[key] = value
+
+    def __call__(self, *args, **kwargs):
+        return self
+
+
+def mock_get_builder(*args, **kwargs):
+    return MockBuilder()
+
+
+def test_supercon_get_builder_from_protocol_prep(
+    fixture_code,
+    generate_structure,
+    generate_remote_data,
+    fixture_localhost,
+    monkeypatch,
+):
+    """Test get_builder_from_protocol for SuperConWorkChain with EpwPrepWorkChain parent."""
+    from aiida_epw.workflows.supercon import SuperConWorkChain
+    from aiida_epw.workflows.base import EpwBaseWorkChain
+    from plumpy.ports import Port, PortNamespace
+
+    monkeypatch.setattr(Port, "validate", lambda *a, **k: None)
+    monkeypatch.setattr(PortNamespace, "validate", lambda *a, **k: None)
+    monkeypatch.setattr(EpwBaseWorkChain, "get_builder_from_protocol", mock_get_builder)
+
+    epw_code = fixture_code("epw.epw")
+    structure = generate_structure()
+    remote_folder = generate_remote_data(fixture_localhost, "/tmp/remote_folder")
+
+    # Mock the EpwPrepWorkChain parent node
+    parent_epw = MagicMock()
+    parent_epw.process_label = "EpwPrepWorkChain"
+    parent_epw.inputs = MagicMock()
+    parent_epw.inputs.structure = structure
+
+    # Mock base.links.get_outgoing
+    epw_source = MagicMock()
+    epw_source.inputs = MagicMock()
+    epw_source.inputs.code = epw_code
+    epw_source.inputs.kpoints = orm.KpointsData()
+    epw_source.inputs.qpoints = orm.KpointsData()
+    epw_source.outputs = MagicMock()
+    epw_source.outputs.remote_folder = remote_folder
+
+    parent_epw.base.links.get_outgoing.return_value.first.return_value.node = epw_source
+
+    builder = SuperConWorkChain.get_builder_from_protocol(
+        epw_code=epw_code,
+        parent_epw=parent_epw,
+        protocol="fast",
+    )
+
+    assert builder.structure is structure
+    assert builder.parent_folder_epw is remote_folder
+
+
+def test_supercon_get_builder_from_protocol_base_success(
+    fixture_code,
+    generate_structure,
+    generate_remote_data,
+    fixture_localhost,
+    monkeypatch,
+):
+    """Test get_builder_from_protocol for SuperConWorkChain with EpwBaseWorkChain parent having structure."""
+    from aiida_epw.workflows.supercon import SuperConWorkChain
+    from aiida_epw.workflows.base import EpwBaseWorkChain
+    from plumpy.ports import Port, PortNamespace
+
+    monkeypatch.setattr(Port, "validate", lambda *a, **k: None)
+    monkeypatch.setattr(PortNamespace, "validate", lambda *a, **k: None)
+    monkeypatch.setattr(EpwBaseWorkChain, "get_builder_from_protocol", mock_get_builder)
+
+    epw_code = fixture_code("epw.epw")
+    structure = generate_structure()
+    remote_folder = generate_remote_data(fixture_localhost, "/tmp/remote_folder")
+
+    # Mock the EpwBaseWorkChain parent node
+    parent_epw = MagicMock()
+    parent_epw.process_label = "EpwBaseWorkChain"
+    parent_epw.inputs = MagicMock()
+    parent_epw.inputs.structure = structure
+    parent_epw.inputs.code = epw_code
+    parent_epw.inputs.kpoints = orm.KpointsData()
+    parent_epw.inputs.qpoints = orm.KpointsData()
+    parent_epw.outputs = MagicMock()
+    parent_epw.outputs.remote_folder = remote_folder
+
+    builder = SuperConWorkChain.get_builder_from_protocol(
+        epw_code=epw_code,
+        parent_epw=parent_epw,
+        protocol="fast",
+    )
+
+    assert builder.structure is structure
+    assert builder.parent_folder_epw is remote_folder
+
+
+def test_supercon_get_builder_from_protocol_base_failure(
+    fixture_code,
+    generate_structure,
+    generate_remote_data,
+    fixture_localhost,
+    monkeypatch,
+):
+    """Test get_builder_from_protocol for SuperConWorkChain with EpwBaseWorkChain parent missing structure raises ValueError."""
+    from aiida_epw.workflows.supercon import SuperConWorkChain
+    from aiida_epw.workflows.base import EpwBaseWorkChain
+    from plumpy.ports import Port, PortNamespace
+
+    monkeypatch.setattr(Port, "validate", lambda *a, **k: None)
+    monkeypatch.setattr(PortNamespace, "validate", lambda *a, **k: None)
+    monkeypatch.setattr(EpwBaseWorkChain, "get_builder_from_protocol", mock_get_builder)
+
+    epw_code = fixture_code("epw.epw")
+    remote_folder = generate_remote_data(fixture_localhost, "/tmp/remote_folder")
+
+    # Mock the EpwBaseWorkChain parent node without structure
+    parent_epw = MagicMock()
+    parent_epw.process_label = "EpwBaseWorkChain"
+    parent_epw.inputs = MagicMock()
+    # Delete structure attribute to raise AttributeError when accessed
+    del parent_epw.inputs.structure
+    parent_epw.inputs.code = epw_code
+    parent_epw.inputs.kpoints = orm.KpointsData()
+    parent_epw.inputs.qpoints = orm.KpointsData()
+    parent_epw.outputs = MagicMock()
+    parent_epw.outputs.remote_folder = remote_folder
+
+    with pytest.raises(ValueError, match="does not contain `structure` in its inputs"):
+        SuperConWorkChain.get_builder_from_protocol(
+            epw_code=epw_code,
+            parent_epw=parent_epw,
+            protocol="fast",
+        )


### PR DESCRIPTION
- If we provide an `EpwPrepWorkChain` as `parent_epw` we cannot get the structure from its `epw_base` sub-process because structure in the `epw_base` sub-process is excluded in the `EpwPrepWorkChain`.
- I use `remote_stash` instead of `remote_folder` as the `parent_folder_epw`.