### PR TITLE
🐛 `SuperConWorkChain`: `epw_interp` can be an empty list if all interpolations fail

### DIFF
--- a/src/aiida_epw/workflows/supercon.py
+++ b/src/aiida_epw/workflows/supercon.py
@@ -415,6 +415,12 @@ class SuperConWorkChain(ProtocolMixin, WorkChain):
 
     def should_run_final(self):
         """Check if the final EpwBaseWorkChain should be run."""
+        if not self.ctx.epw_interp:
+            self.report(
+                "Allen-Dynes interpolation was not successful, epw_interp list is empty."
+            )
+            return self.exit_codes.ERROR_SUB_PROCESS_EPW_INTERP
+
         if self.ctx.is_converged or self.inputs.always_run_final.value:
             return True
         else:

--- a/tests/workflows/test_supercon.py
+++ b/tests/workflows/test_supercon.py
@@ -149,3 +149,60 @@ def test_supercon_get_builder_from_protocol_base_failure(
             parent_epw=parent_epw,
             protocol="fast",
         )
+
+
+def test_supercon_should_run_final():
+    """Test should_run_final with different states of epw_interp and convergence."""
+    from aiida_epw.workflows.supercon import SuperConWorkChain
+    from types import SimpleNamespace
+    from aiida.common.extendeddicts import AttributeDict
+
+    # Mock exit codes
+    class FakeExitCodes:
+        ERROR_SUB_PROCESS_EPW_INTERP = "ERROR_SUB_PROCESS_EPW_INTERP"
+        ERROR_ALLEN_DYNES_NOT_CONVERGED = "ERROR_ALLEN_DYNES_NOT_CONVERGED"
+
+    # Define fake workchain helper
+    def make_fake_workchain(epw_interp_list, is_converged, always_run_final):
+        reports = []
+        ctx = SimpleNamespace(
+            epw_interp=epw_interp_list,
+            is_converged=is_converged,
+        )
+        inputs = AttributeDict(
+            {
+                "always_run_final": SimpleNamespace(value=always_run_final),
+            }
+        )
+        return SimpleNamespace(
+            inputs=inputs,
+            ctx=ctx,
+            exit_codes=FakeExitCodes(),
+            report=reports.append,
+            reports=reports,
+        )
+
+    # 1. epw_interp is empty -> should return ERROR_SUB_PROCESS_EPW_INTERP
+    wc1 = make_fake_workchain(
+        epw_interp_list=[], is_converged=True, always_run_final=True
+    )
+    assert SuperConWorkChain.should_run_final(wc1) == "ERROR_SUB_PROCESS_EPW_INTERP"
+    assert "empty" in wc1.reports[0]
+
+    # 2. epw_interp is not empty, converged -> should return True
+    wc2 = make_fake_workchain(
+        epw_interp_list=[object()], is_converged=True, always_run_final=False
+    )
+    assert SuperConWorkChain.should_run_final(wc2) is True
+
+    # 3. epw_interp is not empty, not converged but always_run_final is True -> should return True
+    wc3 = make_fake_workchain(
+        epw_interp_list=[object()], is_converged=False, always_run_final=True
+    )
+    assert SuperConWorkChain.should_run_final(wc3) is True
+
+    # 4. epw_interp is not empty, not converged, always_run_final is False -> should return ERROR_ALLEN_DYNES_NOT_CONVERGED
+    wc4 = make_fake_workchain(
+        epw_interp_list=[object()], is_converged=False, always_run_final=False
+    )
+    assert SuperConWorkChain.should_run_final(wc4) == "ERROR_ALLEN_DYNES_NOT_CONVERGED"


### PR DESCRIPTION
check whether `epw_interp` is empty in `should_run_final` is empty to avoid `IndexError`