### PR TITLE
🐛 `SuperConWorkChain`: align `a2f` output port type

### DIFF
--- a/src/aiida_epw/workflows/supercon.py
+++ b/src/aiida_epw/workflows/supercon.py
@@ -9,6 +9,7 @@ from aiida.engine import WorkChain, while_, if_, append_
 from aiida_quantumespresso.workflows.protocols.utils import ProtocolMixin
 
 from aiida_epw.workflows.base import EpwBaseWorkChain
+from aiida_epw.data import A2fData
 
 from aiida.engine import calcfunction
 
@@ -189,7 +190,7 @@ class SuperConWorkChain(ProtocolMixin, WorkChain):
         )
         spec.output(
             "a2f",
-            valid_type=orm.XyData,
+            valid_type=A2fData,
             help="The contents of the `.a2f` file for the final EPW.",
         )
         spec.output("Tc_iso", valid_type=orm.Float, help="The critical temperature.")


### PR DESCRIPTION
The `a2f` output port type is updated from `XyData` to `A2fData`