### PR TITLE
✨ Add new `Enum` type: `RestartType`

### DIFF
--- a/src/aiida_epw/calculations/epw.py
+++ b/src/aiida_epw/calculations/epw.py
@@ -85,15 +85,6 @@ class EpwCalculation(NamelistsCalculation):
         ("INPUTEPW", "limag"),
         ("INPUTEPW", "lpade"),
         ("INPUTEPW", "lacon"),
-        ("INPUTEPW", "epwread"),
-        ("INPUTEPW", "epwwrite"),
-        ("INPUTEPW", "epbread"),
-        ("INPUTEPW", "epbwrite"),
-        ("INPUTEPW", "restart"),
-        ("INPUTEPW", "ep_coupling"),
-        ("INPUTEPW", "elph"),
-        ("INPUTEPW", "ephwrite"),
-        ("INPUTEPW", "epmatkqread"),
     ]
 
     _use_kpoints = True

--- a/src/aiida_epw/calculations/epw.py
+++ b/src/aiida_epw/calculations/epw.py
@@ -36,6 +36,27 @@ def _lowercase_dict(dictionary, dict_name):
     return _case_transform_dict(dictionary, dict_name, "_lowercase_dict", str.lower)
 
 
+def serialize_restart_type(value):
+    """Serialize a restart mode to the ``RestartType`` AiiDA enum input."""
+    from aiida.orm import EnumData
+
+    from aiida_epw.common.types import RestartType
+
+    if isinstance(value, EnumData):
+        return value
+    if isinstance(value, RestartType):
+        return EnumData(value)
+    if isinstance(value, str):
+        try:
+            return EnumData(RestartType(value.lower()))
+        except ValueError as exception:
+            raise ValueError(
+                f"Invalid restart type '{value}'. Supported values: "
+                f"{[member.value for member in RestartType]}"
+            ) from exception
+    raise TypeError(f"Cannot serialize {value} to EnumData of RestartType")
+
+
 class EpwCalculation(NamelistsCalculation):
     """`CalcJob` implementation for the epw.x code of Quantum ESPRESSO."""
 
@@ -64,6 +85,15 @@ class EpwCalculation(NamelistsCalculation):
         ("INPUTEPW", "limag"),
         ("INPUTEPW", "lpade"),
         ("INPUTEPW", "lacon"),
+        ("INPUTEPW", "epwread"),
+        ("INPUTEPW", "epwwrite"),
+        ("INPUTEPW", "epbread"),
+        ("INPUTEPW", "epbwrite"),
+        ("INPUTEPW", "restart"),
+        ("INPUTEPW", "ep_coupling"),
+        ("INPUTEPW", "elph"),
+        ("INPUTEPW", "ephwrite"),
+        ("INPUTEPW", "epmatkqread"),
     ]
 
     _use_kpoints = True
@@ -110,6 +140,16 @@ class EpwCalculation(NamelistsCalculation):
             "parameters",
             valid_type=orm.Dict,
             help="Parameters for the `epw.x` input file.",
+        )
+        spec.input(
+            "restart_type",
+            valid_type=orm.EnumData,
+            required=False,
+            serializer=serialize_restart_type,
+            help=(
+                "EPW run/restart mode: none, ephwrite, ephread, "
+                "ephwrite_restart, ephread_restart, or epwread."
+            ),
         )
         spec.input(
             "momentum_dependence",
@@ -396,22 +436,45 @@ class EpwCalculation(NamelistsCalculation):
     @classmethod
     def validate_restart_inputs(cls, parameters, inputs):
         """Validate restart-related input combinations against the EPW parameters."""
+        from aiida_epw.common.types import RestartType
+
         inputepw = parameters["INPUTEPW"]
-
-        if not inputepw.get("wannierize", False):
-            return
-
-        for input_name in ("parent_folder_epw", "parent_folder_chk"):
-            if input_name in inputs:
+        if inputepw.get("wannierize", False):
+            for input_name in ("parent_folder_epw", "parent_folder_chk"):
+                if input_name in inputs:
+                    raise exceptions.InputValidationError(
+                        f"`{input_name}` cannot be specified when "
+                        "`parameters.INPUTEPW.wannierize` is true."
+                    )
+            if "parent_folder_nscf" not in inputs:
                 raise exceptions.InputValidationError(
-                    f"`{input_name}` cannot be specified when "
+                    "`parent_folder_nscf` must be specified when "
                     "`parameters.INPUTEPW.wannierize` is true."
                 )
+            return
 
-        if "parent_folder_nscf" not in inputs:
+        restart_type = (
+            inputs["restart_type"].get_member() if "restart_type" in inputs else None
+        )
+        parent_restart_types = (
+            RestartType.EPHWRITE,
+            RestartType.EPHREAD,
+            RestartType.EPHWRITE_RESTART,
+            RestartType.EPHREAD_RESTART,
+            RestartType.EPWREAD,
+        )
+        uses_parent = restart_type in parent_restart_types
+        has_parent = "parent_folder_epw" in inputs
+
+        if uses_parent != has_parent:
+            if uses_parent:
+                raise exceptions.InputValidationError(
+                    f"`parent_folder_epw` must be specified when "
+                    f"restart_type is '{restart_type.value}'."
+                )
             raise exceptions.InputValidationError(
-                "`parent_folder_nscf` must be specified when "
-                "`parameters.INPUTEPW.wannierize` is true."
+                "`restart_type` must be set to a mode that reads an EPW parent "
+                "when `parent_folder_epw` is provided."
             )
 
     @staticmethod
@@ -718,6 +781,58 @@ class EpwCalculation(NamelistsCalculation):
                 elif ac_method == "none":
                     inputepw_parameters["lpade"] = False
                     inputepw_parameters["lacon"] = False
+
+        if "restart_type" in self.inputs:
+            from aiida_epw.common.types import RestartType
+
+            restart_type = self.inputs.restart_type.get_member()
+            if restart_type is RestartType.NONE:
+                inputepw_parameters.update(
+                    {
+                        "epwread": False,
+                        "epwwrite": True,
+                        "restart": False,
+                        "ep_coupling": True,
+                        "elph": True,
+                        "epbwrite": True,
+                        "epbread": False,
+                    }
+                )
+            elif restart_type in (RestartType.EPHWRITE, RestartType.EPHWRITE_RESTART):
+                inputepw_parameters.update(
+                    {
+                        "epwread": True,
+                        "epwwrite": False,
+                        "restart": restart_type is RestartType.EPHWRITE_RESTART,
+                        "ep_coupling": True,
+                        "elph": True,
+                        "ephwrite": True,
+                    }
+                )
+            elif restart_type in (RestartType.EPHREAD, RestartType.EPHREAD_RESTART):
+                inputepw_parameters.update(
+                    {
+                        "epwread": True,
+                        "restart": restart_type is RestartType.EPHREAD_RESTART,
+                        "ep_coupling": False,
+                        "elph": False,
+                        "ephwrite": False,
+                    }
+                )
+                if inputepw_parameters.get("scattering", False):
+                    inputepw_parameters["epmatkqread"] = True
+            elif restart_type is RestartType.EPWREAD:
+                inputepw_parameters.update(
+                    {
+                        "epwread": True,
+                        "epwwrite": False,
+                        "epbwrite": False,
+                        "epbread": False,
+                        "ep_coupling": True,
+                        "elph": True,
+                    }
+                )
+                inputepw_parameters.setdefault("restart", False)
 
         inputepw_parameters["outdir"] = self._OUTPUT_SUBFOLDER
         inputepw_parameters["dvscf_dir"] = self._FOLDER_SAVE

--- a/src/aiida_epw/common/__init__.py
+++ b/src/aiida_epw/common/__init__.py
@@ -1,0 +1,3 @@
+from .types import RestartType
+
+__all__ = ("RestartType",)

--- a/src/aiida_epw/common/types.py
+++ b/src/aiida_epw/common/types.py
@@ -1,0 +1,12 @@
+import enum
+
+
+class RestartType(enum.Enum):
+    """Enumeration of EPW run/restart modes."""
+
+    NONE = "none"
+    EPHWRITE = "ephwrite"
+    EPHREAD = "ephread"
+    EPHWRITE_RESTART = "ephwrite_restart"
+    EPHREAD_RESTART = "ephread_restart"
+    EPWREAD = "epwread"

--- a/src/aiida_epw/workflows/mobility.py
+++ b/src/aiida_epw/workflows/mobility.py
@@ -5,6 +5,7 @@ from aiida.engine import WorkChain, while_, append_, calcfunction
 
 from aiida_quantumespresso.workflows.protocols.utils import ProtocolMixin
 
+from aiida_epw.calculations.epw import serialize_restart_type
 from aiida_epw.tools.band_analysis import extract_band_edges_from_epw_prep
 from aiida_epw.workflows.base import EpwBaseWorkChain
 
@@ -447,6 +448,7 @@ class MobilityWorkChain(ProtocolMixin, WorkChain):
             "code": self.inputs.epw_mobility.code,
             "structure": self.inputs.structure,
             "parent_folder_epw": self.inputs.parent_folder_epw,
+            "restart_type": serialize_restart_type("ephread_restart"),
             "qfpoints_distance": self.ctx.interpolation_list.pop(0),
             "kfpoints_factor": self.inputs.kfpoints_factor,
             "parameters": orm.Dict(parameters),

--- a/src/aiida_epw/workflows/prep.py
+++ b/src/aiida_epw/workflows/prep.py
@@ -276,6 +276,7 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
                 "parent_folder_nscf",
                 "parent_folder_epw",
                 "parent_folder_chk",
+                "restart_type",
             ),
             namespace_options={"help": "Inputs for the `EpwBaseWorkChain`."},
         )
@@ -292,6 +293,7 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
                 "qfpoints_distance",
                 "kfpoints_factor",
                 "parent_folder_epw",
+                "restart_type",
             ),
             namespace_options={
                 "help": "Inputs namespace for `EpwBaseWorkChain` that runs the `epw.x` calculation in interpolation mode, i.e. the interpolated electron and phonon band structures."
@@ -1189,6 +1191,10 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
 
         inputs.metadata.call_link_label = "epw_base"
 
+        from aiida_epw.common.types import RestartType
+
+        inputs.restart_type = RestartType.NONE
+
         workchain_node = self.submit(EpwBaseWorkChain, **inputs)
         self.report(
             f"launching EpwBaseWorkChain<{workchain_node.pk}> in transformation mode"
@@ -1265,6 +1271,11 @@ class EpwPrepWorkChain(ProtocolMixin, WorkChain):
         inputs.kfpoints = bands_kpoints
         inputs.parent_folder_epw = self.ctx.workchain_epw.outputs.remote_folder
         inputs.metadata.call_link_label = "epw_bands"
+
+        from aiida_epw.common.types import RestartType
+
+        inputs.restart_type = RestartType.EPWREAD
+
         workchain_node = self.submit(EpwBaseWorkChain, **inputs)
         self.report(
             f"launching EpwBaseWorkChain<{workchain_node.pk}> in bands interpolation mode"

--- a/src/aiida_epw/workflows/protocols/mobility.yaml
+++ b/src/aiida_epw/workflows/protocols/mobility.yaml
@@ -21,16 +21,9 @@ default_inputs:
       withmpi: True
     parameters:
       INPUTEPW:
-        elph: True
-        restart: true
         restart_step: 1000
         etf_mem: 3
         # I/O Settings
-        epbwrite: false
-        epbread: false
-        epwwrite: false
-        epwread: true
-        epmatkqread: false
         selecqread: false
         vme: 'wannier' #'wannier' or 'dipole'
         use_ws: true
@@ -61,7 +54,6 @@ default_inputs:
         bfieldx: 0.0
         bfieldy: 0.0
         bfieldz: 1.0e-10
-        wannierize: False
 
 default_protocol: moderate
 protocols:

--- a/src/aiida_epw/workflows/supercon.py
+++ b/src/aiida_epw/workflows/supercon.py
@@ -8,6 +8,7 @@ from aiida.engine import WorkChain, while_, if_, append_
 
 from aiida_quantumespresso.workflows.protocols.utils import ProtocolMixin
 
+from aiida_epw.calculations.epw import serialize_restart_type
 from aiida_epw.workflows.base import EpwBaseWorkChain
 from aiida_epw.data import A2fData
 
@@ -120,6 +121,7 @@ class SuperConWorkChain(ProtocolMixin, WorkChain):
                 "parent_folder_chk",
                 "qfpoints",
                 "kfpoints",
+                "restart_type",
             ),
             namespace_options={
                 "help": (
@@ -138,6 +140,7 @@ class SuperConWorkChain(ProtocolMixin, WorkChain):
                 "parent_folder_chk",
                 "qfpoints_distance",
                 "kfpoints_factor",
+                "restart_type",
             ),
             namespace_options={
                 "help": (
@@ -156,6 +159,7 @@ class SuperConWorkChain(ProtocolMixin, WorkChain):
                 "parent_folder_chk",
                 "qfpoints_distance",
                 "kfpoints_factor",
+                "restart_type",
             ),
             namespace_options={
                 "help": (
@@ -375,6 +379,8 @@ class SuperConWorkChain(ProtocolMixin, WorkChain):
         inputs.kfpoints_factor = self.inputs.epw_interp.kfpoints_factor
         inputs.qfpoints_distance = self.ctx.interpolation_list.pop()
 
+        inputs.restart_type = serialize_restart_type("ephwrite")
+
         if self.ctx.degaussq:
             parameters = inputs.parameters.get_dict()
             parameters["INPUTEPW"]["degaussq"] = self.ctx.degaussq
@@ -440,6 +446,8 @@ class SuperConWorkChain(ProtocolMixin, WorkChain):
         inputs.kfpoints = parent_folder_epw.creator.inputs.kfpoints
         inputs.qfpoints = parent_folder_epw.creator.inputs.qfpoints
 
+        inputs.restart_type = serialize_restart_type("ephread")
+
         if self.ctx.degaussq:
             parameters = inputs.parameters.get_dict()
             parameters["INPUTEPW"]["degaussq"] = self.ctx.degaussq
@@ -475,6 +483,8 @@ class SuperConWorkChain(ProtocolMixin, WorkChain):
         inputs.parent_folder_epw = parent_folder_epw
         inputs.kfpoints = parent_folder_epw.creator.inputs.kfpoints
         inputs.qfpoints = parent_folder_epw.creator.inputs.qfpoints
+
+        inputs.restart_type = serialize_restart_type("ephread")
 
         inputs.metadata.call_link_label = "epw_final_aniso"
         workchain_node = self.submit(EpwBaseWorkChain, **inputs)

--- a/tests/calculations/test_epw_calcjob.py
+++ b/tests/calculations/test_epw_calcjob.py
@@ -10,6 +10,7 @@ from aiida_quantumespresso.calculations.ph import PhCalculation
 from aiida_quantumespresso.calculations.pw import PwCalculation
 
 from aiida_epw.calculations.epw import EpwCalculation
+from aiida_epw.common import RestartType
 
 
 def generate_kpoints_mesh(mesh):
@@ -435,7 +436,8 @@ def test_epw_stages_epw_restart_files_without_copying_epmatwp(
     """Test that EPW restart staging links the large `epmatwp` file and copies metadata files."""
     parent_folder = generate_remote_data(fixture_localhost, "/remote/epw")
     inputs = generate_inputs_epw(
-        parameters={"INPUTEPW": {"epwread": True, "elph": True}},
+        restart_type=RestartType.EPWREAD,
+        parameters={"INPUTEPW": {}},
         parent_folder_epw=parent_folder,
     )
 
@@ -543,3 +545,60 @@ def test_epw_eliashberg_parameters_continuation_none(
     assert "limag = .false." in input_contents
     assert "lpade = .false." in input_contents
     assert "lacon = .false." in input_contents
+
+
+@pytest.mark.parametrize(
+    ("restart_type", "parameters", "expected_entries"),
+    [
+        (
+            RestartType.NONE,
+            {},
+            ("epwread = .false.", "epwwrite = .true.", "epbwrite = .true."),
+        ),
+        (
+            RestartType.EPHWRITE_RESTART,
+            {},
+            ("epwread = .true.", "restart = .true.", "ephwrite = .true."),
+        ),
+        (
+            RestartType.EPHREAD,
+            {"scattering": True},
+            ("epwread = .true.", "ep_coupling = .false.", "epmatkqread = .true."),
+        ),
+        (
+            RestartType.EPWREAD,
+            {},
+            ("epwread = .true.", "epwwrite = .false.", "epbwrite = .false."),
+        ),
+    ],
+)
+def test_epw_restart_type_parameter(
+    fixture_sandbox,
+    fixture_localhost,
+    generate_calc_job,
+    generate_inputs_epw,
+    generate_remote_data,
+    restart_type,
+    parameters,
+    expected_entries,
+):
+    """Restart modes write the plugin-managed EPW input keywords."""
+    inputs = generate_inputs_epw(
+        restart_type=restart_type,
+        parameters={"INPUTEPW": parameters},
+        **(
+            {}
+            if restart_type is RestartType.NONE
+            else {
+                "parent_folder_epw": generate_remote_data(
+                    fixture_localhost, "/remote/epw"
+                )
+            }
+        ),
+    )
+
+    generate_calc_job(fixture_sandbox, "epw.epw", inputs)
+    input_contents = Path(fixture_sandbox.abspath, "aiida.in").read_text()
+
+    for entry in expected_entries:
+        assert entry in input_contents

--- a/tests/calculations/test_epw_calcjob.py
+++ b/tests/calculations/test_epw_calcjob.py
@@ -116,6 +116,25 @@ def test_epw_rejects_plugin_managed_keywords(
         generate_calc_job(fixture_sandbox, "epw.epw", inputs)
 
 
+@pytest.mark.parametrize(
+    "key",
+    [
+        "epwread",
+        "epwwrite",
+        "epbread",
+        "epbwrite",
+        "restart",
+        "ep_coupling",
+        "elph",
+        "ephwrite",
+        "epmatkqread",
+    ],
+)
+def test_epw_allows_user_restart_keywords(key):
+    """Test that restart-related parameters are not rejected as plugin-managed."""
+    EpwCalculation.validate_blocked_keywords({"INPUTEPW": {key: True}})
+
+
 def test_epw_accepts_user_filkf_filqf(
     fixture_sandbox, generate_calc_job, generate_inputs_epw
 ):

--- a/tests/workflows/test_mobility.py
+++ b/tests/workflows/test_mobility.py
@@ -1,0 +1,17 @@
+"""Tests for the mobility workflow protocol."""
+
+
+def test_mobility_protocol_omits_plugin_managed_parameters():
+    """Mobility protocols leave EPW run/restart flags to ``RestartType``."""
+    from aiida_epw.calculations.epw import EpwCalculation
+    from aiida_epw.workflows.mobility import MobilityWorkChain
+
+    inputs = MobilityWorkChain.get_protocol_inputs("fast")
+    parameters = inputs["epw_mobility"]["parameters"]["INPUTEPW"]
+    managed = {
+        key
+        for namelist, key in EpwCalculation._blocked_keywords
+        if namelist == "INPUTEPW"
+    }
+
+    assert managed.isdisjoint(parameters)

--- a/tests/workflows/test_supercon.py
+++ b/tests/workflows/test_supercon.py
@@ -206,3 +206,22 @@ def test_supercon_should_run_final():
         epw_interp_list=[object()], is_converged=False, always_run_final=False
     )
     assert SuperConWorkChain.should_run_final(wc4) == "ERROR_ALLEN_DYNES_NOT_CONVERGED"
+
+
+def test_epw_base_restart_types(fixture_code, generate_structure):
+    """Test that EpwBaseWorkChain exposes restart_type from EpwCalculation."""
+    from aiida_epw.workflows.base import EpwBaseWorkChain
+    from aiida_epw.common import RestartType
+
+    epw_code = fixture_code("epw.epw")
+    structure = generate_structure()
+
+    builder = EpwBaseWorkChain.get_builder_from_protocol(
+        code=epw_code,
+        structure=structure,
+        protocol="fast",
+    )
+
+    # We should be able to set and access restart_type on the builder
+    builder.restart_type = RestartType.EPHWRITE
+    assert builder.restart_type == RestartType.EPHWRITE


### PR DESCRIPTION
This PR introduces `RestartType` to describe where an `epw.x` run starts and
which restart artifacts it consumes.

Supported modes:

- `NONE`: start from the coarse representation and write reusable EPW data.
- `EPWREAD`: read the coarse EPW representation for band interpolation.
- `EPHWRITE`: interpolate onto the fine grids and write the `prefix.ephmat` data.
- `EPHWRITE_RESTART`: resume an interrupted `EPHWRITE` calculation.
- `EPHREAD`: read completed `prefix.ephmat` data.
- `EPHREAD_RESTART`: resume an `EPHREAD`-stage calculation, including mobility.

The calculation plugin owns the associated low-level EPW flags. Prep,
SuperCon, and mobility workflows select the restart mode internally instead of
duplicating those flags in protocol files.

This PR contains no `CalculationType`.

Validation: CalcJob, Prep, SuperCon, and mobility tests pass locally.
