### PR TITLE
✨ error-handling: handle Pade approximation failures

### DIFF
--- a/src/aiida_epw/calculations/epw.py
+++ b/src/aiida_epw/calculations/epw.py
@@ -357,6 +357,11 @@ class EpwCalculation(NamelistsCalculation):
             "ERROR_CANNOT_BRACKET_EF",
             message="Internal error, cannot bracket Ef.",
         )
+        spec.exit_code(
+            321,
+            "ERROR_PADE_APPROXIMANTS",
+            message="The Pade approximants calculation failed (NaN values detected).",
+        )
 
     @classmethod
     def normalize_parameters(cls, parameters):

--- a/src/aiida_epw/parsers/epw.py
+++ b/src/aiida_epw/parsers/epw.py
@@ -202,7 +202,10 @@ class EpwParser(BaseParser):
         if "Allen_Dynes_Tc" in parsed_data:
             parsed_data.setdefault("allen_dynes", parsed_data["Allen_Dynes_Tc"])
 
-        self.out("output_parameters", orm.Dict(parsed_data))
+        self.out("output_parameters", orm.Dict(self.clean_nans(parsed_data)))
+
+        if "ERROR_PADE_APPROXIMANTS" in logs.error:
+            return self.exit(self.exit_codes.get("ERROR_PADE_APPROXIMANTS"), logs)
 
         for exit_code in list(self.get_error_map().values()):
             if exit_code in logs.error:
@@ -214,6 +217,23 @@ class EpwParser(BaseParser):
             )
 
         return self.exit(logs=logs)
+
+    @staticmethod
+    def clean_nans(value):
+        """Recursively replace float('nan'), float('inf'), and float('-inf') in dictionaries/lists with None."""
+        import math
+
+        if isinstance(value, float):
+            if math.isnan(value) or math.isinf(value):
+                return None
+            return value
+        if isinstance(value, dict):
+            return {k: EpwParser.clean_nans(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [EpwParser.clean_nans(v) for v in value]
+        if isinstance(value, tuple):
+            return tuple(EpwParser.clean_nans(v) for v in value)
+        return value
 
     @staticmethod
     def parse_stdout(stdout, logs, code_version=None):
@@ -396,6 +416,19 @@ class EpwParser(BaseParser):
         from aiida_epw.tools.parsers import parse_stdout_eliashberg
 
         parsed_data.update(parse_stdout_eliashberg(stdout))
+
+        # Check for Pade approximation failure (NaN values under the pade table header)
+        pade_header_match = re.search(
+            r"pade\s+Re\[znorm\]\s+Re\[delta\]\s+\[meV\]\s+Re\[shift\]\s+\[meV\]",
+            stdout,
+        )
+        if pade_header_match:
+            start_idx = pade_header_match.end()
+            remaining = stdout[start_idx:].lstrip()
+            if remaining:
+                first_line = remaining.split("\n", 1)[0]
+                if "nan" in first_line.lower():
+                    logs.error.append("ERROR_PADE_APPROXIMANTS")
 
         return parsed_data, logs
 

--- a/src/aiida_epw/tools/error_handling/__init__.py
+++ b/src/aiida_epw/tools/error_handling/__init__.py
@@ -1,0 +1,5 @@
+"""Error-recovery helpers used by EPW work chains."""
+
+from . import supercon
+
+__all__ = ("supercon",)

--- a/src/aiida_epw/tools/error_handling/supercon.py
+++ b/src/aiida_epw/tools/error_handling/supercon.py
@@ -1,0 +1,178 @@
+"""Pade error-recovery helpers for EPW workflows."""
+
+from copy import deepcopy
+
+
+def prepare_pade_recovery(parameters, output_parameters, max_nsiw, min_nsiw):
+    """Return updated inputs and an action for a recoverable Pade failure.
+
+    Returns ``(None, None)`` when neither the Pade order nor the temperature
+    list can be adjusted further.
+    """
+    parameters = deepcopy(parameters)
+    outputs = output_parameters
+    eliashberg_data = (
+        outputs.get("isotropic_eliashberg")
+        or outputs.get("anisotropic_eliashberg")
+        or {}
+    )
+    succeeded_temps = _get_succeeded_temperatures(eliashberg_data)
+
+    input_epw = parameters.get("INPUTEPW", {})
+    all_temps, is_linear_range = _get_input_temperatures(input_epw, eliashberg_data)
+    remaining_temps = [
+        temp
+        for temp in all_temps
+        if not any(abs(temp - succeeded) < 1.0e-4 for succeeded in succeeded_temps)
+    ]
+
+    nsiw = _get_first_value(eliashberg_data, remaining_temps, "nsiw")
+    if nsiw is None:
+        nsiw = input_epw.get("nsiw")
+    current_npade = input_epw.get("npade", 90)
+    current_iterations = _get_first_value(
+        eliashberg_data, remaining_temps, "nsiter", nested_key="pade"
+    )
+    target_npade = _get_target_npade(
+        input_epw, nsiw, current_npade, current_iterations, max_nsiw, min_nsiw
+    )
+
+    input_epw_new = parameters.setdefault("INPUTEPW", {})
+    new_temps = (
+        [remaining_temps[0], remaining_temps[-1]]
+        if is_linear_range and len(remaining_temps) >= 2
+        else remaining_temps
+    )
+    input_epw_new["temps"] = (
+        " ".join(str(temp) for temp in new_temps)
+        if isinstance(input_epw.get("temps"), str)
+        else new_temps
+    )
+    input_epw_new["nstemp"] = len(remaining_temps)
+    input_epw_new.pop("tempsmin", None)
+    input_epw_new.pop("tempsmax", None)
+
+    action_taken = ""
+    if target_npade is not None and target_npade != current_npade:
+        input_epw_new["npade"] = target_npade
+        action_taken += f"Reduced npade from {current_npade} to {target_npade}. "
+    if len(remaining_temps) < len(all_temps):
+        succeeded = [
+            temp
+            for temp in all_temps
+            if any(abs(temp - value) < 1.0e-4 for value in succeeded_temps)
+        ]
+        action_taken += f"Removed successfully calculated temperatures: {succeeded}. "
+
+    if not action_taken:
+        return None, None
+
+    return parameters, action_taken
+
+
+def _get_succeeded_temperatures(eliashberg_data):
+    """Return temperatures whose reported Eliashberg data contain no failure marker."""
+    succeeded_temps = []
+    for temp_str, data in eliashberg_data.items():
+        iterations = data.get("iterations", {})
+        pade = data.get("pade", {})
+        has_failed = False
+        if iterations:
+            if not iterations.get("ethr") or any(
+                value is None for value in iterations.get("ethr", [])
+            ):
+                has_failed = True
+            elif any(value is None for value in iterations.get("znormi", [])) or any(
+                value is None for value in iterations.get("deltai", [])
+            ):
+                has_failed = True
+        if pade and any(
+            pade.get(key) is None for key in ("delta", "znorm", "shift") if key in pade
+        ):
+            has_failed = True
+        if not iterations and not pade:
+            has_failed = True
+        if not has_failed:
+            succeeded_temps.append(float(temp_str))
+    return succeeded_temps
+
+
+def _get_input_temperatures(input_epw, eliashberg_data):
+    """Return the explicit temperature sequence and whether it was a linear range."""
+    if "temps" in input_epw:
+        temps = input_epw["temps"]
+        if isinstance(temps, str):
+            original_temps = [float(temp) for temp in temps.replace(",", " ").split()]
+        elif isinstance(temps, (int, float)):
+            original_temps = [float(temps)]
+        else:
+            original_temps = [float(temp) for temp in temps]
+        nstemp = input_epw.get("nstemp", len(original_temps))
+        if len(original_temps) == 2 and nstemp >= 2:
+            return (
+                [
+                    original_temps[0]
+                    + index * (original_temps[1] - original_temps[0]) / (nstemp - 1)
+                    for index in range(nstemp)
+                ],
+                True,
+            )
+        return original_temps, False
+    if {"tempsmin", "tempsmax", "nstemp"} <= input_epw.keys():
+        temp_min = float(input_epw["tempsmin"])
+        temp_max = float(input_epw["tempsmax"])
+        nstemp = int(input_epw["nstemp"])
+        if nstemp > 1:
+            return (
+                [
+                    temp_min + index * (temp_max - temp_min) / (nstemp - 1)
+                    for index in range(nstemp)
+                ],
+                True,
+            )
+        return [temp_min], True
+    return [float(temp) for temp in eliashberg_data], False
+
+
+def _get_first_value(eliashberg_data, temperatures, key, nested_key=None):
+    """Return the first value matching a remaining input temperature."""
+    for temperature in temperatures:
+        for data_temperature, data in eliashberg_data.items():
+            if abs(float(data_temperature) - temperature) < 1.0e-4:
+                value = (
+                    data.get(nested_key, {}).get(key) if nested_key else data.get(key)
+                )
+                if value is not None:
+                    return value
+    return None
+
+
+def _get_target_npade(
+    input_epw, nsiw, current_npade, current_iterations, max_nsiw, min_nsiw
+):
+    """Calculate a lower Pade iteration count compatible with the current mesh."""
+    if current_iterations is None and nsiw is not None:
+        divisor = (
+            2
+            if input_epw.get("fbw", False) and not input_epw.get("positive_matsu", True)
+            else 1
+        )
+        current_iterations = int(current_npade * (nsiw / divisor) / 100)
+    if current_iterations is None or not nsiw:
+        return None
+
+    target_iterations = (
+        max_nsiw
+        if current_iterations > max_nsiw
+        else max(min_nsiw, int(current_iterations * 0.5))
+    )
+    divisor = (
+        2
+        if input_epw.get("fbw", False) and not input_epw.get("positive_matsu", True)
+        else 1
+    )
+    target_npade = int(target_iterations * 100 / (nsiw / divisor))
+    target_npade = max(1, min(100, target_npade))
+    if target_npade == current_npade and current_npade > 1:
+        return max(1, current_npade - 5)
+    return target_npade

--- a/src/aiida_epw/workflows/base.py
+++ b/src/aiida_epw/workflows/base.py
@@ -19,6 +19,7 @@ from aiida_quantumespresso.workflows.protocols.utils import ProtocolMixin
 from aiida.orm.nodes.data.base import to_aiida_type
 
 from aiida_epw.tools.kpoints import check_kpoints_qpoints_compatibility
+from aiida_epw.tools.error_handling import supercon as supercon_error_handling
 
 EpwCalculation = CalculationFactory("epw.epw")
 
@@ -80,6 +81,9 @@ def validate_inputs(  # pylint: disable=unused-argument,inconsistent-return-stat
 
 class EpwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
     """BaseWorkchain to run a epw.x calculation."""
+
+    _MAX_NSIW = 200
+    _MIN_NSIW = 20
 
     _process_class = EpwCalculation
 
@@ -484,7 +488,7 @@ class EpwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         self.report("{}<{}> failed with exit status {}: {}".format(*arguments))
         self.report(f"Action taken: {action}")
 
-    @process_handler(priority=600)
+    @process_handler(priority=10)
     def handle_unrecoverable_failure(self, calculation):
         """Handle calculations with an exit status below 400 which are unrecoverable, so abort the work chain."""
         if calculation.is_failed and calculation.exit_status < 400:
@@ -620,3 +624,35 @@ class EpwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
         return ProcessHandlerReport(
             True, self.exit_codes.ERROR_KNOWN_UNRECOVERABLE_FAILURE
         )
+
+    @process_handler(
+        priority=400,
+        exit_codes=[EpwCalculation.exit_codes.ERROR_PADE_APPROXIMANTS],
+    )
+    def handle_pade_approximants(self, calculation):
+        """Handle exit code 322 (Pade NaN failure) by reducing nsiw and popping successful temperatures."""
+        parameters, action_taken = supercon_error_handling.prepare_pade_recovery(
+            self.ctx.inputs.parameters.get_dict(),
+            calculation.outputs.output_parameters.get_dict(),
+            self._MAX_NSIW,
+            self._MIN_NSIW,
+        )
+        if action_taken is None:
+            self.report_error_handled(
+                calculation,
+                "Cannot reduce npade further or pop temperatures. Aborting.",
+            )
+            return ProcessHandlerReport(
+                True, self.exit_codes.ERROR_KNOWN_UNRECOVERABLE_FAILURE
+            )
+
+        try:
+            from aiida_epw.common.types import RestartType
+
+            self.ctx.inputs.restart_type = RestartType.EPHREAD
+        except ImportError:
+            parameters.setdefault("INPUTEPW", {})["epwread"] = True
+        self.ctx.inputs.parameters = orm.Dict(parameters)
+        self.ctx.inputs.parent_folder_epw = calculation.outputs.remote_folder
+        self.report_error_handled(calculation, action_taken)
+        return ProcessHandlerReport(True)

--- a/tests/files/parsers/epw/failed_pade_approximation/aiida.out
+++ b/tests/files/parsers/epw/failed_pade_approximation/aiida.out
@@ -1,0 +1,351 @@
+                                                                                      
+                                       ``:oss/                                        
+                           `.+s+.     .+ys--yh+     `./ss+.                           
+                          -sh//yy+`   +yy   +yy    -+h+-oyy                           
+                          -yh- .oyy/.-sh.   .syo-.:sy-  /yh                           
+                 `.-.`    `yh+   -oyyyo.     `/syys:    oys      `.`                  
+               `/+ssys+-` `sh+      `                   oys`   .:osyo`                
+               -yh- ./syyooyo`                          .sys+/oyo--yh/                
+               `yy+    .-:-.                             `-/+/:`  -sh-                
+                /yh.                                              oys                 
+          ``..---hho---------`   .---------..`      `.-----.`    -hd+---.             
+       `./osmNMMMMMMMMMMMMMMMs. +NNMMMMMMMMNNmh+.   yNMMMMMNm-  oNMMMMMNmo++:`        
+       +sy--/sdMMMhyyyyyyyNMMh- .oyNMMmyyyyyhNMMm+` -yMMMdyyo:` .oyyNMMNhs+syy`       
+       -yy/   /MMM+.`-+/``mMMy-   `mMMh:`````.dMMN:` `MMMy-`-dhhy```mMMy:``+hs        
+        -yy+` /MMMo:-mMM+`-oo/.    mMMh:     `dMMN/`  dMMm:`dMMMMy..MMMo-.+yo`        
+         .sys`/MMMMNNMMMs-         mMMmyooooymMMNo:   oMMM/sMMMMMM++MMN//oh:          
+          `sh+/MMMhyyMMMs- `-`     mMMMMMMMMMNmy+-`   -MMMhMMMsmMMmdMMd/yy+           
+    `-/+++oyy-/MMM+.`/hh/.`mNm:`   mMMd+/////:-.`      NMMMMMd/:NMMMMMy:/yyo/:.`      
+   +os+//:-..-oMMMo:--:::-/MMMo. .-mMMd+---`           hMMMMN+. oMMMMMo. `-+osyso:`   
+   syo     `mNMMMMMNNNNNNNNMMMo.oNNMMMMMNNNN:`         +MMMMs:`  dMMMN/`     ``:syo   
+   /yh`     :syyyyyyyyyyyyyyyy+.`+syyyyyyyyo:`         .oyys:`   .oyys:`        +yh   
+   -yh-        ````````````````    `````````              ``        ``          oys   
+   -+h/------------------------::::::::://////++++++++++++++++++++++///////::::/yd:   
+   shdddddddddddddddddddddddddddddhhhhhhhhyyyyyssssssssssssssssyyyyyyyhhhhhhhddddh`   
+                                                                                      
+ Lee, H., Poncé, S., Bushick, K., Hajinazar, S., Lafuente-Bartolome, J.,Leveillee, J.,
+    Lian, C., Lihm, J., Macheda, F., Mori, H., Paudyal, H., Sio, W., Tiwari, S.,      
+ Zacharias, M., Zhang, X., Bonini, N., Kioupakis, E., Margine, E.R., and Giustino F., 
+                                                     npj Comput Mater 9, 156 (2023)   
+                                                                                      
+
+     Program EPW v.6.0 starts on 25Jun2026 at 17:15:22 
+
+     This program is part of the open-source Quantum ESPRESSO suite
+     for quantum simulation of materials; please cite
+         "P. Giannozzi et al., J. Phys.:Condens. Matter 21 395502 (2009);
+         "P. Giannozzi et al., J. Phys.:Condens. Matter 29 465901 (2017);
+         "P. Giannozzi et al., J. Chem. Phys. 152 154105 (2020);
+          URL http://www.quantum-espresso.org", 
+     in publications or presentations arising from this work. More details at
+     http://www.quantum-espresso.org/quote
+
+     Parallel version (MPI & OpenMP), running on     128 processor cores
+     Number of MPI processes:               128
+     Threads/MPI process:                     1
+
+     MPI processes distributed on     1 nodes
+     K-points division:     npool     =     128
+     233509 MiB available memory on the printing compute node when the environment starts
+
+     Reading input from aiida.in
+      Title line not specified: using 'default'.
+
+     Generating evenly spaced temperature list.
+                      
+     ------------------------------------------------------------------------ 
+                   RESTART - RESTART - RESTART - RESTART                         
+     Restart is done without reading PWSCF save file.                  
+     Be aware that some consistency checks are therefore not done.                  
+     ------------------------------------------------------------------------ 
+                      
+
+     default                                                                    
+
+     bravais-lattice index     =            0
+     lattice parameter (a_0)   =       0.0000  a.u.
+     unit-cell volume          =       0.0000 (a.u.)^3
+     number of atoms/cell      =            0
+     number of atomic types    =            0
+     kinetic-energy cut-off    =       0.0000  Ry
+     charge density cut-off    =       0.0000  Ry
+     Exchange-correlation= not set
+                           (  -1  -1  -1  -1  -1  -1  -1)
+
+
+     celldm(1)=    0.00000  celldm(2)=    0.00000  celldm(3)=    0.00000
+     celldm(4)=    0.00000  celldm(5)=    0.00000  celldm(6)=    0.00000
+
+     crystal axes: (cart. coord. in units of a_0)
+               a(1) = (  0.0000  0.0000  0.0000 )  
+               a(2) = (  0.0000  0.0000  0.0000 )  
+               a(3) = (  0.0000  0.0000  0.0000 )  
+
+     reciprocal axes: (cart. coord. in units 2 pi/a_0)
+               b(1) = (  0.0000  0.0000  0.0000 )  
+               b(2) = (  0.0000  0.0000  0.0000 )  
+               b(3) = (  0.0000  0.0000  0.0000 )  
+
+
+     Atoms inside the unit cell: 
+
+   Cartesian axes
+
+     site n.  atom      mass           positions (a_0 units)
+
+
+     No symmetry!
+
+     G cutoff =    0.0000  (      0 G-vectors)     FFT grid: (  0,  0,  0)
+     number of k points=    0
+                       cart. coord. in units 2pi/a_0
+
+     ===================================================================
+     Solve full-bandwidth isotropic Eliashberg equations
+     ===================================================================
+
+
+     Finish reading freq file
+
+                  Fermi level (eV) =     1.1347915324E+01
+     DOS(states/spin/eV/Unit Cell) =     3.1493409263E-01
+            Electron smearing (eV) =     5.0000000000E-02
+                 Fermi window (eV) =     8.0000000000E-01
+     Nr k-points within the Fermi shell =      1130 out of      3375
+
+           2 bands within the Fermi window
+
+
+     Finish reading egnv file 
+
+
+     Max nr of q-points =      1130
+
+
+     Finish reading ikmap files
+
+
+     Start reading .ephmat files
+
+
+     Finish reading .ephmat files
+
+     a2f file is found and will be used to estimate initial gap
+ 
+
+     Finish reading a2f file
+
+     Electron-phonon coupling strength =    1.2658267
+ 
+     Estimated Tc using McMillan expression =   6.3282 K for muc =   0.1300
+  
+     Estimated Tc using Allen-Dynes modified McMillan expression =   6.7964 K
+  
+     Estimated Tc using SISSO machine learning model =   6.7229 K
+  
+     Estimated w_log =   6.3939 meV
+  
+     Estimated BCS superconducting gap using McMillan Tc =   0.9598 meV
+  
+  
+     WARNING WARNING WARNING 
+  
+     The code may crash since tempsmax =   10.000 K is larger than McMillan Tc =     6.328 K
+
+     Start reading dos file aiida.dos
+
+ 
+
+     Finish reading dos file aiida.dos
+
+ 
+     Actual number of frequency points (     1) =    923 for uniform       sampling
+    
+     temp(  1) =      1.00000 K
+    
+     Solve full-bandwidth isotropic Eliashberg equations on imaginary-axis
+    
+     Total number of frequency points nsiw(     1) =    923
+     Cutoff frequency wscut =     0.5000 eV
+     Maximum frequency =         0.4995 eV
+     broyden mixing factor =      0.70000
+    
+        startiw = 1, lastiw = 923, nsiw(itemp) = 923
+        iter      ethr          znormi      deltai [meV]   shifti [meV]    mu (eV)
+          1   1.955151E+00   2.371782E+00   2.210584E+00  -1.185599E+00   1.134792E+01
+          2   8.694986E-01   2.097359E+00   1.772487E+00  -8.526210E-01   1.134792E+01
+          3   9.949484E-02   2.090447E+00   1.749082E+00  -8.729510E-01   1.134792E+01
+          4   3.070477E-02   2.092728E+00   1.731728E+00  -8.605152E-01   1.134792E+01
+          5   2.975657E-03   2.093612E+00   1.726291E+00  -8.594232E-01   1.134792E+01
+     Convergence was reached in nsiter =      5
+ 
+     Chemical potential (itemp =   1) =     1.1347915324E+01 eV
+ 
+     Temp (itemp =   1) =    1.000 K  Free energy =    -0.004309 meV
+ 
+     iaxis_imag   :      0.02s CPU      0.63s WALL (       1 calls)
+ 
+    
+     Pade approximant of full-bandwidth isotropic Eliashberg equations from imaginary-axis to real-axis
+     Cutoff frequency wscut =     0.5000
+    
+        pade    Re[znorm]   Re[delta] [meV]   Re[shift] [meV]
+        830            NaN            NaN            NaN
+     Convergence was reached for N =    830 Pade approximants
+ 
+     raxis_pade   :      0.18s CPU      4.19s WALL (       1 calls)
+ 
+     itemp =   1   total cpu time :     4.8 secs
+ 
+     Actual number of frequency points (     2) =    462 for uniform       sampling
+    
+     temp(  2) =      2.00000 K
+    
+     Solve full-bandwidth isotropic Eliashberg equations on imaginary-axis
+    
+     Total number of frequency points nsiw(     2) =    462
+     Cutoff frequency wscut =     0.5000 eV
+     Maximum frequency =         0.4998 eV
+     broyden mixing factor =      0.70000
+    
+        startiw = 1, lastiw = 462, nsiw(itemp) = 462
+        iter      ethr          znormi      deltai [meV]   shifti [meV]    mu (eV)
+          1            NaN            NaN            NaN            NaN   1.134792E+01
+          2            NaN            NaN            NaN            NaN   1.134792E+01
+          3            NaN            NaN            NaN            NaN   1.134792E+01
+          4            NaN            NaN            NaN            NaN   1.134792E+01
+
+ %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+     Error in routine mix_broyden (1):
+     factorization
+ %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+     stopping ...
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries
+[CRAYBLAS_WARNING] Application linked against multiple cray-libsci libraries

--- a/tests/parsers/test_epw.py
+++ b/tests/parsers/test_epw.py
@@ -1,5 +1,7 @@
 """Tests for the `EpwParser`."""
 
+import textwrap
+
 import pytest
 from aiida import orm
 from aiida.common import LinkType
@@ -84,6 +86,69 @@ def test_epw_failed_broyden_factor(parse_from_files, data_regression):
         {
             "output_parameters": results["output_parameters"].get_dict(),
         }
+    )
+
+
+def test_epw_failed_pade_approximation(parse_from_files, data_regression):
+    """Test a `epw.x` that failed due to NaN in Pade approximation."""
+    results, calcfunction = parse_from_files(EpwParser, "failed_pade_approximation")
+    expected_exit_status = EpwCalculation.exit_codes.ERROR_PADE_APPROXIMANTS.status
+
+    assert calcfunction.is_failed
+    assert calcfunction.exit_status == expected_exit_status
+    data_regression.check(
+        {
+            "output_parameters": results["output_parameters"].get_dict(),
+        }
+    )
+
+
+def test_epw_iteration_nan_without_pade_is_not_pade_failure(aiida_localhost):
+    """Test that NaN values in imaginary-axis iterations do not imply a Pade failure."""
+    import io
+
+    stdout_content = textwrap.dedent(
+        """\
+        Program EPW v.6.0
+        EPW v6.0
+        temp(   1) =     6.00000 K
+        Solve full-bandwidth isotropic Eliashberg equations on imaginary-axis
+        Total number of frequency points nsiw(   1) =    154
+        Cutoff frequency wscut =     0.5000 eV
+        broyden mixing factor =      0.70000
+        startiw = 1, lastiw = 154, nsiw(itemp) = 154
+        iter      ethr          znormi      deltai [meV]   shifti [meV]    mu (eV)
+          1   2.012636E+00   2.017502E+00   8.075927E-01   6.275953E-01   1.130935E+01
+          2   5.312233E+00   1.907240E+00   8.809776E-23   3.834545E-01   1.130935E+01
+          3            NaN            NaN            NaN            NaN   1.130935E+01
+        """
+    )
+
+    parser_entry_point = get_entry_point_string_from_class(
+        class_module=EpwParser.__module__, class_name=EpwParser.__name__
+    )
+    calc_entry_point = format_entry_point_string(
+        group="aiida.calculations", name=parser_entry_point.split(":")[1]
+    )
+
+    node = orm.CalcJobNode(computer=aiida_localhost, process_type=calc_entry_point)
+    node.base.attributes.set("output_filename", "aiida.out")
+    node.store()
+
+    retrieved = orm.FolderData()
+    retrieved.base.repository.put_object_from_filelike(
+        io.BytesIO(stdout_content.encode("utf-8")), "aiida.out"
+    )
+    retrieved.base.links.add_incoming(
+        node, link_type=LinkType.CREATE, link_label="retrieved"
+    )
+    retrieved.store()
+
+    _, calcfunction = EpwParser.parse_from_node(node, store_provenance=False)
+
+    assert (
+        calcfunction.exit_status
+        != EpwCalculation.exit_codes.ERROR_PADE_APPROXIMANTS.status
     )
 
 

--- a/tests/parsers/test_epw/test_epw_failed_pade_approximation.yml
+++ b/tests/parsers/test_epw/test_epw_failed_pade_approximation.yml
@@ -1,0 +1,93 @@
+output_parameters:
+  Allen_Dynes_Tc: 6.7964
+  BCS_gap: 0.9598
+  DOS: 3.1493409263
+  McMillan_Tc: 6.3282
+  SISSO_Tc: 6.7229
+  allen_dynes: 6.7964
+  code_version: '6.0'
+  electron_smearing: 5.0
+  fermi_level: 1.1347915324
+  fermi_window: 8.0
+  isotropic_eliashberg:
+    '1.0':
+      broyden_mixing_factor: 0.7
+      free_energy: -0.004309
+      iterations:
+        deltai:
+        - 2.210584
+        - 1.772487
+        - 1.749082
+        - 1.731728
+        - 1.726291
+        ethr:
+        - 1.955151
+        - 0.8694986
+        - 0.09949484
+        - 0.03070477
+        - 0.002975657
+        mu:
+        - 11.34792
+        - 11.34792
+        - 11.34792
+        - 11.34792
+        - 11.34792
+        shifti:
+        - -1.185599
+        - -0.852621
+        - -0.872951
+        - -0.8605152
+        - -0.8594232
+        znormi:
+        - 2.371782
+        - 2.097359
+        - 2.090447
+        - 2.092728
+        - 2.093612
+      lastiw: 923
+      nsiter: 5
+      nsiw: 923
+      nsiw_itemp: 923
+      pade:
+        delta: null
+        nsiter: 830
+        shift: null
+        znorm: null
+      startiw: 1
+      wscut: 0.5
+    '2.0':
+      broyden_mixing_factor: 0.7
+      iterations:
+        deltai:
+        - null
+        - null
+        - null
+        - null
+        ethr:
+        - null
+        - null
+        - null
+        - null
+        mu:
+        - 11.34792
+        - 11.34792
+        - 11.34792
+        - 11.34792
+        shifti:
+        - null
+        - null
+        - null
+        - null
+        znormi:
+        - null
+        - null
+        - null
+        - null
+      lastiw: 462
+      nsiw: 462
+      nsiw_itemp: 462
+      startiw: 1
+      wscut: 0.5
+  lambda: 1.2658267
+  muc: 0.13
+  w_log: 6.3939

--- a/tests/workflows/test_base.py
+++ b/tests/workflows/test_base.py
@@ -1,9 +1,371 @@
-"""Tests for the ``EpwBaseWorkChain``."""
+"""Tests for the `EpwBaseWorkChain` class and its error handlers."""
+
+from unittest.mock import MagicMock
 
 import pytest
 from aiida import orm
 
+try:
+    from aiida_epw.common.types import RestartType
+
+    HAS_RESTART_TYPE = True
+except ImportError:
+    HAS_RESTART_TYPE = False
 from aiida_epw.workflows.base import EpwBaseWorkChain
+
+
+def test_handle_pade_approximants(aiida_localhost):
+    """Test the handle_pade_approximants error handler with successful/failed temperatures and nsiw reduction."""
+
+    class MockWorkChain:
+        _MAX_NSIW = EpwBaseWorkChain._MAX_NSIW
+        _MIN_NSIW = EpwBaseWorkChain._MIN_NSIW
+        exit_codes = EpwBaseWorkChain.exit_codes
+
+        def __init__(self):
+            self.ctx = MagicMock()
+            self.report_messages = []
+
+        def report(self, msg):
+            self.report_messages.append(msg)
+
+        def report_error_handled(self, calculation, action):
+            self.report(f"Calculation failed: {action}")
+
+        handle_pade_approximants = EpwBaseWorkChain.handle_pade_approximants
+
+    workchain = MockWorkChain()
+
+    # Mock calculation
+    calc = MagicMock()
+    calc.outputs = MagicMock()
+    calc.outputs.remote_folder = orm.RemoteData(
+        computer=aiida_localhost, remote_path="/tmp"
+    )
+
+    # Mock outputs: 2.0 succeeded, 1.0 failed
+    calc.outputs.output_parameters = orm.Dict(
+        dict={
+            "isotropic_eliashberg": {
+                "2.0": {
+                    "nsiw": 400,
+                    "iterations": {"ethr": [1e-8], "znormi": [1.2], "deltai": [2.5]},
+                    "pade": {"delta": 2.4, "znorm": 1.2},
+                },
+                "1.0": {
+                    "nsiw": 800,
+                    "iterations": {"ethr": [None], "znormi": [None], "deltai": [None]},
+                    "pade": {"delta": None, "znorm": None},
+                },
+            }
+        }
+    )
+
+    # Setup ctx inputs
+    initial_params = {"INPUTEPW": {"temps": [1.0, 2.0], "nstemp": 2}}
+    workchain.ctx.inputs = MagicMock()
+    workchain.ctx.inputs.parameters = orm.Dict(dict=initial_params)
+
+    # Run handler
+    report = workchain.handle_pade_approximants.__wrapped__(calc)
+
+    # Assertions
+    assert report.do_break is True
+    assert report.exit_code.status == 0
+
+    updated_params = workchain.ctx.inputs.parameters.get_dict()
+    input_epw = updated_params["INPUTEPW"]
+
+    # Successfully calculated temperature 2.0 should be popped
+    assert input_epw["temps"] == [1.0]
+    assert input_epw["nstemp"] == 1
+
+    # npade should be reduced to 25 to achieve N=200 with nsiw=800
+    assert input_epw["npade"] == 25
+
+    # Restart settings should be set
+    if HAS_RESTART_TYPE:
+        assert workchain.ctx.inputs.restart_type == RestartType.EPHREAD
+    else:
+        assert input_epw.get("epwread") is True
+    assert workchain.ctx.inputs.parent_folder_epw == calc.outputs.remote_folder
+
+
+def test_handle_pade_approximants_lower_bound(aiida_localhost):
+    """Test that nsiw reduction respects the lower bound threshold (min limit)."""
+
+    class MockWorkChain:
+        _MAX_NSIW = EpwBaseWorkChain._MAX_NSIW
+        _MIN_NSIW = EpwBaseWorkChain._MIN_NSIW
+        exit_codes = EpwBaseWorkChain.exit_codes
+
+        def __init__(self):
+            self.ctx = MagicMock()
+            self.report_messages = []
+
+        def report(self, msg):
+            self.report_messages.append(msg)
+
+        def report_error_handled(self, calculation, action):
+            self.report(f"Calculation failed: {action}")
+
+        handle_pade_approximants = EpwBaseWorkChain.handle_pade_approximants
+
+    workchain = MockWorkChain()
+
+    # Mock calculation
+    calc = MagicMock()
+    calc.outputs = MagicMock()
+    calc.outputs.remote_folder = orm.RemoteData(
+        computer=aiida_localhost, remote_path="/tmp"
+    )
+
+    # Mock output where nsiw is already small
+    calc.outputs.output_parameters = orm.Dict(
+        dict={
+            "isotropic_eliashberg": {
+                "1.0": {
+                    "nsiw": 30,
+                    "iterations": {"ethr": [None], "znormi": [None], "deltai": [None]},
+                }
+            }
+        }
+    )
+
+    # Setup ctx inputs
+    initial_params = {"INPUTEPW": {"temps": [1.0], "nstemp": 1}}
+    workchain.ctx.inputs = MagicMock()
+    workchain.ctx.inputs.parameters = orm.Dict(dict=initial_params)
+
+    # Run handler
+    report = workchain.handle_pade_approximants.__wrapped__(calc)
+
+    # Assertions
+    assert report.do_break is True
+    assert report.exit_code.status == 0
+
+    updated_params = workchain.ctx.inputs.parameters.get_dict()
+    # nsiw=30, current_N = 90*30/100 = 27. target_N = 20. npade = 20*100/30 = 66
+    assert updated_params["INPUTEPW"]["npade"] == 66
+
+
+def test_handle_pade_approximants_string_temps(aiida_localhost):
+    """Test that the handler works correctly when temps is a space-separated string."""
+
+    class MockWorkChain:
+        _MAX_NSIW = EpwBaseWorkChain._MAX_NSIW
+        _MIN_NSIW = EpwBaseWorkChain._MIN_NSIW
+        exit_codes = EpwBaseWorkChain.exit_codes
+
+        def __init__(self):
+            self.ctx = MagicMock()
+            self.report_messages = []
+
+        def report(self, msg):
+            self.report_messages.append(msg)
+
+        def report_error_handled(self, calculation, action):
+            self.report(f"Calculation failed: {action}")
+
+        handle_pade_approximants = EpwBaseWorkChain.handle_pade_approximants
+
+    workchain = MockWorkChain()
+
+    # Mock calculation
+    calc = MagicMock()
+    calc.outputs = MagicMock()
+    calc.outputs.remote_folder = orm.RemoteData(
+        computer=aiida_localhost, remote_path="/tmp"
+    )
+
+    # Mock outputs: 2.0 succeeded, 1.0 failed
+    calc.outputs.output_parameters = orm.Dict(
+        dict={
+            "isotropic_eliashberg": {
+                "2.0": {
+                    "nsiw": 400,
+                    "iterations": {"ethr": [1e-8], "znormi": [1.2], "deltai": [2.5]},
+                    "pade": {"delta": 2.4, "znorm": 1.2},
+                },
+                "1.0": {
+                    "nsiw": 800,
+                    "iterations": {"ethr": [None], "znormi": [None], "deltai": [None]},
+                    "pade": {"delta": None, "znorm": None},
+                },
+            }
+        }
+    )
+
+    # Setup ctx inputs with space-separated string
+    initial_params = {"INPUTEPW": {"temps": "1.0 2.0", "nstemp": 2}}
+    workchain.ctx.inputs = MagicMock()
+    workchain.ctx.inputs.parameters = orm.Dict(dict=initial_params)
+
+    # Run handler
+    report = workchain.handle_pade_approximants.__wrapped__(calc)
+
+    # Assertions
+    assert report.do_break is True
+    assert report.exit_code.status == 0
+
+    updated_params = workchain.ctx.inputs.parameters.get_dict()
+    input_epw = updated_params["INPUTEPW"]
+
+    # Successfully calculated temperature 2.0 should be popped
+    # And since the original input was a string, the result should also be a string
+    assert input_epw["temps"] == "1.0"
+    assert input_epw["nstemp"] == 1
+    # npade should be reduced to 25 to achieve N=200 with nsiw=800
+    assert input_epw["npade"] == 25
+
+
+def test_handle_pade_approximants_linear_range(aiida_localhost):
+    """Test that the handler correctly pops a linear range of temperatures."""
+
+    class MockWorkChain:
+        _MAX_NSIW = EpwBaseWorkChain._MAX_NSIW
+        _MIN_NSIW = EpwBaseWorkChain._MIN_NSIW
+        exit_codes = EpwBaseWorkChain.exit_codes
+
+        def __init__(self):
+            self.ctx = MagicMock()
+            self.report_messages = []
+
+        def report(self, msg):
+            self.report_messages.append(msg)
+
+        def report_error_handled(self, calculation, action):
+            self.report(f"Calculation failed: {action}")
+
+        handle_pade_approximants = EpwBaseWorkChain.handle_pade_approximants
+
+    workchain = MockWorkChain()
+
+    # Mock calculation
+    calc = MagicMock()
+    calc.outputs = MagicMock()
+    calc.outputs.remote_folder = orm.RemoteData(
+        computer=aiida_localhost, remote_path="/tmp"
+    )
+
+    # Mock outputs: 1.0, 2.0, 3.0, 4.0 succeeded, 5.0 failed
+    calc.outputs.output_parameters = orm.Dict(
+        dict={
+            "isotropic_eliashberg": {
+                "1.0": {
+                    "nsiw": 100,
+                    "iterations": {"ethr": [1e-8]},
+                    "pade": {"delta": 2.4, "znorm": 1.2},
+                },
+                "2.0": {
+                    "nsiw": 100,
+                    "iterations": {"ethr": [1e-8]},
+                    "pade": {"delta": 2.4, "znorm": 1.2},
+                },
+                "3.0": {
+                    "nsiw": 100,
+                    "iterations": {"ethr": [1e-8]},
+                    "pade": {"delta": 2.4, "znorm": 1.2},
+                },
+                "4.0": {
+                    "nsiw": 100,
+                    "iterations": {"ethr": [1e-8]},
+                    "pade": {"delta": 2.4, "znorm": 1.2},
+                },
+                "5.0": {
+                    "nsiw": 100,
+                    "iterations": {"ethr": [None]},
+                    "pade": {"delta": None, "znorm": None},
+                },
+            }
+        }
+    )
+
+    # Setup ctx inputs as range from 1.0 to 10.0 with 10 values
+    initial_params = {"INPUTEPW": {"temps": "1.0 10.0", "nstemp": 10}}
+    workchain.ctx.inputs = MagicMock()
+    workchain.ctx.inputs.parameters = orm.Dict(dict=initial_params)
+
+    # Run handler
+    report = workchain.handle_pade_approximants.__wrapped__(calc)
+
+    # Assertions
+    assert report.do_break is True
+    assert report.exit_code.status == 0
+
+    updated_params = workchain.ctx.inputs.parameters.get_dict()
+    input_epw = updated_params["INPUTEPW"]
+
+    # 1.0, 2.0, 3.0, 4.0 are popped out. Remaining range starts at 5.0 and ends at 10.0
+    # There are 6 temperatures remaining in the sequence (5.0, 6.0, 7.0, 8.0, 9.0, 10.0)
+    assert input_epw["temps"] == "5.0 10.0"
+    assert input_epw["nstemp"] == 6
+
+
+def test_handle_pade_approximants_range_nstemp_2(aiida_localhost):
+    """Test that the handler correctly processes linear range with nstemp=2."""
+
+    class MockWorkChain:
+        _MAX_NSIW = EpwBaseWorkChain._MAX_NSIW
+        _MIN_NSIW = EpwBaseWorkChain._MIN_NSIW
+        exit_codes = EpwBaseWorkChain.exit_codes
+
+        def __init__(self):
+            self.ctx = MagicMock()
+            self.report_messages = []
+
+        def report(self, msg):
+            self.report_messages.append(msg)
+
+        def report_error_handled(self, calculation, action):
+            self.report(f"Calculation failed: {action}")
+
+        handle_pade_approximants = EpwBaseWorkChain.handle_pade_approximants
+
+    workchain = MockWorkChain()
+
+    # Mock calculation
+    calc = MagicMock()
+    calc.outputs = MagicMock()
+    calc.outputs.remote_folder = orm.RemoteData(
+        computer=aiida_localhost, remote_path="/tmp"
+    )
+
+    # Mock outputs: 1.0 succeeded, 10.0 failed
+    calc.outputs.output_parameters = orm.Dict(
+        dict={
+            "isotropic_eliashberg": {
+                "1.0": {
+                    "nsiw": 100,
+                    "iterations": {"ethr": [1e-8]},
+                    "pade": {"delta": 2.4, "znorm": 1.2},
+                },
+                "10.0": {
+                    "nsiw": 100,
+                    "iterations": {"ethr": [None]},
+                    "pade": {"delta": None, "znorm": None},
+                },
+            }
+        }
+    )
+
+    # Setup ctx inputs: "1.0 10.0" with nstemp=2
+    initial_params = {"INPUTEPW": {"temps": "1.0 10.0", "nstemp": 2}}
+    workchain.ctx.inputs = MagicMock()
+    workchain.ctx.inputs.parameters = orm.Dict(dict=initial_params)
+
+    # Run handler
+    report = workchain.handle_pade_approximants.__wrapped__(calc)
+
+    assert report.do_break is True
+    assert report.exit_code.status == 0
+
+    updated_params = workchain.ctx.inputs.parameters.get_dict()
+    input_epw = updated_params["INPUTEPW"]
+
+    # Since 1.0 succeeded and 10.0 failed, only 10.0 remains
+    assert input_epw["temps"] == "10.0"
+    assert input_epw["nstemp"] == 1
 
 
 def test_get_builder_from_protocol_eliashberg_ports(fixture_code, generate_structure):


### PR DESCRIPTION
## Dependency

This PR depends on #60, which in turn depends on #57. Review the Pade-specific delta after those parser PRs.

## Summary

- Detect NaN values specifically in Pade output sections and emit `ERROR_PADE_APPROXIMANTS`.
- Add an `EpwBaseWorkChain` handler that reduces `npade` within safe limits and retries.
- Preserve non-Pade imaginary-axis NaN values without misclassifying them as a Pade failure.
- Keep the parser and workflow regression fixtures focused on this failure mode.

This PR does not move or modify `parse_transport_matrices`.

## Validation

- `uvx hatch run pre-commit:run --all-files`
- `uvx hatch test -py=3.13` (126 passed, 2 skipped)