### PR TITLE
✨ error-handling: handle temperatures above the superconducting range

### DIFF
--- a/src/aiida_epw/calculations/epw.py
+++ b/src/aiida_epw/calculations/epw.py
@@ -379,6 +379,16 @@ class EpwCalculation(NamelistsCalculation):
         )
         # yapf: enable
         spec.exit_code(
+            321,
+            "ERROR_FACTORIZATION",
+            message="Error in routine mix_broyden (5): factorization.",
+        )
+        spec.exit_code(
+            323,
+            "ERROR_TEMPERATURE_OUT_OF_RANGE",
+            message="Temperature is out of range (reached phase transition, delta converged to zero).",
+        )
+        spec.exit_code(
             314,
             "ERROR_PARAMETERS_NOT_VALID",
             message="The parameters are not valid.",

--- a/src/aiida_epw/parsers/epw.py
+++ b/src/aiida_epw/parsers/epw.py
@@ -1,3 +1,6 @@
+"""Parser for the EPW calculations."""
+
+import math
 import re
 from pathlib import Path
 
@@ -206,6 +209,14 @@ class EpwParser(BaseParser):
 
         if "ERROR_PADE_APPROXIMANTS" in logs.error:
             return self.exit(self.exit_codes.get("ERROR_PADE_APPROXIMANTS"), logs)
+
+        if "ERROR_TEMPERATURE_OUT_OF_RANGE" in logs.error:
+            return self.exit(
+                self.exit_codes.get("ERROR_TEMPERATURE_OUT_OF_RANGE"), logs
+            )
+
+        if "ERROR_FACTORIZATION" in logs.error:
+            return self.exit(self.exit_codes.get("ERROR_FACTORIZATION"), logs)
 
         for exit_code in list(self.get_error_map().values()):
             if exit_code in logs.error:
@@ -429,6 +440,44 @@ class EpwParser(BaseParser):
                 first_line = remaining.split("\n", 1)[0]
                 if "nan" in first_line.lower():
                     logs.error.append("ERROR_PADE_APPROXIMANTS")
+
+        def get_last_finite_deltai(deltai):
+            for value in reversed(deltai):
+                if isinstance(value, (int, float)) and math.isfinite(value):
+                    return value
+            return None
+
+        def has_non_finite_iteration(iterations):
+            return any(
+                isinstance(value, (int, float)) and not math.isfinite(value)
+                for values in iterations.values()
+                for value in values
+            )
+
+        has_gap_collapse = False
+        has_iteration_failure = False
+        for eliashberg_key in ("isotropic_eliashberg", "anisotropic_eliashberg"):
+            if eliashberg_key not in parsed_data:
+                continue
+            for temp_data in parsed_data[eliashberg_key].values():
+                iterations = temp_data.get("iterations", {})
+                deltai = iterations.get("deltai", [])
+                last_finite_deltai = get_last_finite_deltai(deltai)
+                if last_finite_deltai is not None and abs(last_finite_deltai) < 1e-10:
+                    has_gap_collapse = True
+                if iterations and has_non_finite_iteration(iterations):
+                    has_iteration_failure = True
+
+        # Check for factorization / temperature out of range failure
+        has_factorization_error = re.search(
+            r"Error in routine mix_broyden \(\d+\):\s*factorization",
+            stdout,
+            re.IGNORECASE,
+        )
+        if has_gap_collapse and (has_factorization_error or has_iteration_failure):
+            logs.error.append("ERROR_TEMPERATURE_OUT_OF_RANGE")
+        elif has_factorization_error:
+            logs.error.append("ERROR_FACTORIZATION")
 
         return parsed_data, logs
 

--- a/src/aiida_epw/tools/error_handling/supercon.py
+++ b/src/aiida_epw/tools/error_handling/supercon.py
@@ -176,3 +176,11 @@ def _get_target_npade(
     if target_npade == current_npade and current_npade > 1:
         return max(1, current_npade - 5)
     return target_npade
+
+
+def get_temperature_out_of_range_action():
+    """Return the action for a superconducting phase transition."""
+    return (
+        "Temperature reached phase transition (delta converged to zero). "
+        "Finishing workchain successfully."
+    )

--- a/src/aiida_epw/tools/parsers.py
+++ b/src/aiida_epw/tools/parsers.py
@@ -777,9 +777,18 @@ def parse_stdout_eliashberg(stdout: str) -> dict:
         re.IGNORECASE,
     )
 
+    def include_preceding_temperature(match_start: int) -> int:
+        """Include a nearby temperature line that EPW may print before the solver header."""
+        window_start = max(0, match_start - 1000)
+        prefix = stdout[window_start:match_start]
+        matches = list(
+            re.finditer(r"temp\(\s*\d+\)\s*=\s*[\d.]+\s*K", prefix, re.IGNORECASE)
+        )
+        return window_start + matches[-1].start() if matches else match_start
+
     iso_match = isotropic_pattern.search(stdout)
     if iso_match:
-        iso_content = stdout[iso_match.start() :]
+        iso_content = stdout[include_preceding_temperature(iso_match.start()) :]
         aniso_match_in_iso = anisotropic_pattern.search(iso_content)
         if aniso_match_in_iso:
             iso_content = iso_content[: aniso_match_in_iso.start()]
@@ -793,7 +802,7 @@ def parse_stdout_eliashberg(stdout: str) -> dict:
 
     aniso_match = anisotropic_pattern.search(stdout)
     if aniso_match:
-        aniso_content = stdout[aniso_match.start() :]
+        aniso_content = stdout[include_preceding_temperature(aniso_match.start()) :]
         iso_match_in_aniso = isotropic_pattern.search(aniso_content)
         if iso_match_in_aniso:
             aniso_content = aniso_content[: iso_match_in_aniso.start()]

--- a/src/aiida_epw/workflows/base.py
+++ b/src/aiida_epw/workflows/base.py
@@ -654,5 +654,21 @@ class EpwBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):
             parameters.setdefault("INPUTEPW", {})["epwread"] = True
         self.ctx.inputs.parameters = orm.Dict(parameters)
         self.ctx.inputs.parent_folder_epw = calculation.outputs.remote_folder
+
+        self.report_error_handled(calculation, action_taken)
+        return ProcessHandlerReport(True)
+
+    @process_handler(
+        priority=450,
+        exit_codes=[EpwCalculation.exit_codes.ERROR_TEMPERATURE_OUT_OF_RANGE],
+    )
+    def handle_temperature_out_of_range(self, calculation):
+        """Handle exit code 323 (Temperature out of range / phase transition reached).
+
+        Since the gap has converged to zero, we consider the physical calculation complete
+        and exit the workchain successfully.
+        """
+        action_taken = supercon_error_handling.get_temperature_out_of_range_action()
+        self.ctx.is_finished = True
         self.report_error_handled(calculation, action_taken)
         return ProcessHandlerReport(True)

--- a/tests/parsers/test_epw.py
+++ b/tests/parsers/test_epw.py
@@ -72,12 +72,12 @@ def test_epw(parse_from_files, data_regression, test_name):
 
 
 def test_epw_failed_broyden_factor(parse_from_files, data_regression):
-    """Test a `epw.x` that failed due to an error in routine `mix_broyden`."""
+    """Test that a collapsed gap is classified as a temperature-range failure."""
     results, calcfunction = parse_from_files(
         EpwParser, "isotropic/fsr/failed_broyden_factor"
     )
     expected_exit_status = (
-        EpwCalculation.exit_codes.ERROR_OUTPUT_STDOUT_INCOMPLETE.status
+        EpwCalculation.exit_codes.ERROR_TEMPERATURE_OUT_OF_RANGE.status
     )
 
     assert calcfunction.is_failed

--- a/tests/parsers/test_epw_temperature.py
+++ b/tests/parsers/test_epw_temperature.py
@@ -1,0 +1,58 @@
+"""Tests for Eliashberg temperature-range error detection."""
+
+import textwrap
+
+import pytest
+from aiida_quantumespresso.utils.mapping import get_logging_container
+from packaging.version import Version
+
+from aiida_epw.parsers.epw import EpwParser
+
+
+@pytest.mark.parametrize(
+    ("iterations", "failure", "expected_error"),
+    (
+        (
+            "1  1.0E-02  1.1  1.0E-01",
+            "Error in routine mix_broyden (5): factorization",
+            "ERROR_FACTORIZATION",
+        ),
+        (
+            "1  1.0E-02  1.1  1.0E-11",
+            "Error in routine mix_broyden (5): factorization",
+            "ERROR_TEMPERATURE_OUT_OF_RANGE",
+        ),
+        (
+            "\n".join(
+                (
+                    "1  2.0E+00  2.0  8.0E-01",
+                    "2  5.0E+00  1.9  8.0E-23",
+                    "3  NaN      NaN  NaN",
+                )
+            ),
+            "",
+            "ERROR_TEMPERATURE_OUT_OF_RANGE",
+        ),
+    ),
+)
+def test_temperature_range_classification(iterations, failure, expected_error):
+    """Distinguish ordinary factorization failures from a collapsed gap."""
+    stdout = textwrap.dedent(
+        f"""\
+        Program EPW v.6.0
+        temp(1) = 10.0 K
+        Solve isotropic Eliashberg equations on imaginary-axis
+        Total number of frequency points nsiw(1) = 200
+        Cutoff frequency wscut = 0.500 eV
+        broyden mixing factor = 0.700
+        startiw = 1, lastiw = 200, nsiw(itemp) = 200
+        iter  ethr  znormi  deltai [meV]
+        {iterations}
+        {failure}
+        """
+    )
+    logs = get_logging_container()
+
+    _, logs = EpwParser.parse_stdout(stdout, logs, code_version=Version("6.0"))
+
+    assert expected_error in logs.error

--- a/tests/workflows/test_base.py
+++ b/tests/workflows/test_base.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock
 
 import pytest
 from aiida import orm
-
 try:
     from aiida_epw.common.types import RestartType
 
@@ -14,8 +13,38 @@ except ImportError:
 from aiida_epw.workflows.base import EpwBaseWorkChain
 
 
+def test_handle_temperature_out_of_range(aiida_localhost):
+    """Test the temperature-range handler terminates successfully."""
+
+    class MockWorkChain:
+        exit_codes = EpwBaseWorkChain.exit_codes
+
+        def __init__(self):
+            self.ctx = MagicMock()
+            self.ctx.is_finished = False
+            self.report_messages = []
+
+        def report(self, msg):
+            self.report_messages.append(msg)
+
+        def report_error_handled(self, calculation, action):
+            self.report(f"Calculation failed: {action}")
+
+        handle_temperature_out_of_range = (
+            EpwBaseWorkChain.handle_temperature_out_of_range
+        )
+
+    workchain = MockWorkChain()
+    report = workchain.handle_temperature_out_of_range.__wrapped__(MagicMock())
+
+    assert report.do_break is True
+    assert report.exit_code.status == 0
+    assert workchain.ctx.is_finished is True
+    assert any("phase transition" in msg for msg in workchain.report_messages)
+
+
 def test_handle_pade_approximants(aiida_localhost):
-    """Test the handle_pade_approximants error handler with successful/failed temperatures and nsiw reduction."""
+    """Test the Pade handler with successful and failed temperatures."""
 
     class MockWorkChain:
         _MAX_NSIW = EpwBaseWorkChain._MAX_NSIW
@@ -72,7 +101,6 @@ def test_handle_pade_approximants(aiida_localhost):
     # Assertions
     assert report.do_break is True
     assert report.exit_code.status == 0
-
     updated_params = workchain.ctx.inputs.parameters.get_dict()
     input_epw = updated_params["INPUTEPW"]
 

--- a/tests/workflows/test_base.py
+++ b/tests/workflows/test_base.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from aiida import orm
+
 try:
     from aiida_epw.common.types import RestartType
 


### PR DESCRIPTION
## Dependency

This PR depends on #60, which in turn depends on #57.

## Summary

- Distinguish an ordinary Broyden factorization failure from gap collapse at or above the superconducting phase transition.
- Emit `ERROR_TEMPERATURE_OUT_OF_RANGE` when the last finite gap is below `1e-10` and factorization/non-finite iterations follow.
- Treat this physical terminal condition as successful completion in `EpwBaseWorkChain`.
- Keep Pade-approximation error handling exclusively in #61.
- Add focused parser and workflow regression tests.

## Scope

This PR does not move transport parsing code and does not include the Pade exit code.

## Validation

- Full test suite: 123 passed, 2 skipped
- Pre-commit checks: passed