### PR TITLE
♻️ Update protocol files upon the new enumeration types

### DIFF
--- a/src/aiida_epw/workflows/protocols/mobility.yaml
+++ b/src/aiida_epw/workflows/protocols/mobility.yaml
@@ -24,6 +24,11 @@ default_inputs:
         restart_step: 1000
         etf_mem: 3
         # I/O Settings
+        epbwrite: false
+        epbread: false
+        epwwrite: false
+        epwread: true
+        epmatkqread: false
         selecqread: false
         vme: 'wannier' #'wannier' or 'dipole'
         use_ws: true
@@ -54,6 +59,7 @@ default_inputs:
         bfieldx: 0.0
         bfieldy: 0.0
         bfieldz: 1.0e-10
+        wannierize: False
 
 default_protocol: moderate
 protocols:

--- a/src/aiida_epw/workflows/protocols/mobility.yaml
+++ b/src/aiida_epw/workflows/protocols/mobility.yaml
@@ -21,6 +21,8 @@ default_inputs:
       withmpi: True
     parameters:
       INPUTEPW:
+        elph: True
+        restart: true
         restart_step: 1000
         etf_mem: 3
         # I/O Settings

--- a/src/aiida_epw/workflows/protocols/prep.yaml
+++ b/src/aiida_epw/workflows/protocols/prep.yaml
@@ -55,16 +55,13 @@ default_inputs:
         a2f: False
         degaussq: 0.05
         degaussw: 0.2
-        elph: True
         epbread: False
         epbwrite: True
-        epwread: False
-        epwwrite: True
         fsthick: 100
         phonselfen: False
         temps: 300
         vme: 'dipole'
-        wannierize: False
+    restart_type: wannierize
   epw_bands:
     options:
       resources:
@@ -73,12 +70,9 @@ default_inputs:
     parameters:
       INPUTEPW:
         band_plot: True
-        elph: True
         epbread: False
         epbwrite: False
-        epwread: True
-        epwwrite: False
-        wannierize: False
+    restart_type: ephread
 default_protocol: moderate
 protocols:
   moderate:

--- a/src/aiida_epw/workflows/protocols/prep.yaml
+++ b/src/aiida_epw/workflows/protocols/prep.yaml
@@ -55,12 +55,12 @@ default_inputs:
         a2f: False
         degaussq: 0.05
         degaussw: 0.2
-        epbread: False
-        epbwrite: True
+        elph: True
         fsthick: 100
         phonselfen: False
         temps: 300
         vme: 'dipole'
+        wannierize: False
     restart_type: wannierize
   epw_bands:
     options:
@@ -70,9 +70,7 @@ default_inputs:
     parameters:
       INPUTEPW:
         band_plot: True
-        epbread: False
-        epbwrite: False
-    restart_type: ephread
+    restart_type: epwread
 default_protocol: moderate
 protocols:
   moderate:

--- a/src/aiida_epw/workflows/protocols/prep_sc.yaml
+++ b/src/aiida_epw/workflows/protocols/prep_sc.yaml
@@ -55,16 +55,13 @@ default_inputs:
         a2f: False
         degaussq: 0.05
         degaussw: 0.2
-        elph: True
         epbread: False
         epbwrite: True
-        epwread: False
-        epwwrite: True
         fsthick: 100
         phonselfen: False
         temps: 300
         vme: 'dipole'
-        wannierize: False
+    restart_type: wannierize
   epw_bands:
     options:
       resources:
@@ -73,12 +70,9 @@ default_inputs:
     parameters:
       INPUTEPW:
         band_plot: True
-        elph: True
         epbread: False
         epbwrite: False
-        epwread: True
-        epwwrite: False
-        wannierize: False
+    restart_type: ephread
 default_protocol: moderate
 protocols:
   moderate:

--- a/src/aiida_epw/workflows/protocols/prep_sc.yaml
+++ b/src/aiida_epw/workflows/protocols/prep_sc.yaml
@@ -55,8 +55,7 @@ default_inputs:
         a2f: False
         degaussq: 0.05
         degaussw: 0.2
-        epbread: False
-        epbwrite: True
+        elph: True
         fsthick: 100
         phonselfen: False
         temps: 300
@@ -70,9 +69,7 @@ default_inputs:
     parameters:
       INPUTEPW:
         band_plot: True
-        epbread: False
-        epbwrite: False
-    restart_type: ephread
+    restart_type: epwread
 default_protocol: moderate
 protocols:
   moderate:

--- a/src/aiida_epw/workflows/protocols/supercon.yaml
+++ b/src/aiida_epw/workflows/protocols/supercon.yaml
@@ -18,37 +18,28 @@ default_inputs:
         num_machines: 1
       max_wallclock_seconds: 43200  # Twelve hours
       withmpi: True
+    restart_type: ephwrite
+    momentum_dependence: False
+    analytical_continuation: pade
     parameters:
       INPUTEPW:
         broyden_beta: 0.4
         conv_thr_iaxis: 0.01
         degaussq: 0.5
         degaussw: 0.1
-        eliashberg: True
-        elph: True
-        ep_coupling: True
         epbread: False
         epbwrite: False
-        ephwrite: True
         eps_acoustic: 1
-        epwread: True
-        epwwrite: False
         etf_mem: 1
         fsthick: 0.8
-        liso: True
-        laniso: False
-        limag: True
-        lpade: True
         mp_mesh_k: True
         muc: 0.13
         nqstep: 500
         nsiter: 1
         nstemp: 1
-        restart: False
         selecqread: False
         temps: 10.0
         vme: 'dipole'
-        wannierize: False
         wscut: 0.5
   epw_final_iso:
     options:
@@ -56,37 +47,28 @@ default_inputs:
         num_machines: 1
       max_wallclock_seconds: 43200  # Twelve hours
       withmpi: True
+    restart_type: ephread
     parameters:
       INPUTEPW:
         conv_thr_iaxis: 0.01
         degaussq: 0.5
         degaussw: 0.1
         elecselfen: False
-        eliashberg: True
-        ep_coupling: False
         epbread: False
         epbwrite: False
-        ephwrite: False  
-        epwread: True
-        epwwrite: False
         eps_acoustic: 0.1  # cm^{-1}
         etf_mem: 1
         fsthick: 0.8
-        laniso: False
-        limag: True
-        liso: True
         mp_mesh_k: True
         muc: 0.13
         nqstep: 500
         nsiter: 500
         nstemp: 40
-        restart: True
         selecqread:  False
         tc_linear: True
         tc_linear_solver: 'power'   
         temps: 1 40
         vme: 'dipole'
-        wannierize: False
         wscut: 0.5
   epw_final_aniso:
     options:
@@ -94,35 +76,26 @@ default_inputs:
         num_machines: 1
       max_wallclock_seconds: 43200  # Twelve hours
       withmpi: True
+    restart_type: ephread
     parameters:
       INPUTEPW:
         conv_thr_iaxis: 0.01
         degaussq: 0.5
         degaussw: 0.1
         elecselfen: False
-        eliashberg: True
-        ep_coupling: False
         epbread: False
         epbwrite: False
-        ephwrite: False
-        epwread: True
-        epwwrite: False
         eps_acoustic: 0.1  # cm^{-1}
         etf_mem: 1
         fsthick: 0.8
-        laniso: True
-        limag: True
-        liso: False
         # mp_mesh_k: True
         muc: 0.13
         nqstep: 500
         nsiter: 500
         nstemp: 20
-        restart: True
         selecqread:  False
         temps: 5 43
         vme: 'dipole'
-        wannierize: False
         wscut: 0.5
 default_protocol: moderate
 protocols:

--- a/src/aiida_epw/workflows/protocols/supercon.yaml
+++ b/src/aiida_epw/workflows/protocols/supercon.yaml
@@ -23,12 +23,13 @@ default_inputs:
     analytical_continuation: pade
     parameters:
       INPUTEPW:
+        eliashberg: True
+        elph: True
+        ep_coupling: True
         broyden_beta: 0.4
         conv_thr_iaxis: 0.01
         degaussq: 0.5
         degaussw: 0.1
-        epbread: False
-        epbwrite: False
         eps_acoustic: 1
         etf_mem: 1
         fsthick: 0.8
@@ -41,6 +42,7 @@ default_inputs:
         temps: 10.0
         vme: 'dipole'
         wscut: 0.5
+        wannierize: False
   epw_final_iso:
     options:
       resources:
@@ -50,12 +52,13 @@ default_inputs:
     restart_type: ephread
     parameters:
       INPUTEPW:
+        eliashberg: True
+        elph: True
+        ep_coupling: True
         conv_thr_iaxis: 0.01
         degaussq: 0.5
         degaussw: 0.1
         elecselfen: False
-        epbread: False
-        epbwrite: False
         eps_acoustic: 0.1  # cm^{-1}
         etf_mem: 1
         fsthick: 0.8
@@ -70,6 +73,7 @@ default_inputs:
         temps: 1 40
         vme: 'dipole'
         wscut: 0.5
+        wannierize: False
   epw_final_aniso:
     options:
       resources:
@@ -79,12 +83,13 @@ default_inputs:
     restart_type: ephread
     parameters:
       INPUTEPW:
+        eliashberg: True
+        elph: True
+        ep_coupling: True
         conv_thr_iaxis: 0.01
         degaussq: 0.5
         degaussw: 0.1
         elecselfen: False
-        epbread: False
-        epbwrite: False
         eps_acoustic: 0.1  # cm^{-1}
         etf_mem: 1
         fsthick: 0.8
@@ -97,6 +102,7 @@ default_inputs:
         temps: 5 43
         vme: 'dipole'
         wscut: 0.5
+        wannierize: False
 default_protocol: moderate
 protocols:
   moderate:


### PR DESCRIPTION
⚠️ This PR can be merged now but it would be better if you firstly merge PR #59 #58 #55 .

We have defined several new enumeration types such as `RestartType` and `CalculationType`. The relevant input parameters are blocked in `EpwCalculation` so they should be removed from the protocol files.
